### PR TITLE
CMake: Configure builds for Libs and Unit-testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,3 +11,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(DISCCORD_BUILD_STATIC "build disccord as a static library" OFF)
 
 add_subdirectory(lib)
+add_subdirectory(tests)
+enable_testing ()
+
+## add all relevant unit tests here
+add_test (NAME libdisscord_test COMMAND DisccordTest)
+
+
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,10 @@
 find_package(cpprest REQUIRED)
-include_directories(${cpprestsdk_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${cpprestsdk_LIBRARIES})
+find_package(Boost 1.58.0 REQUIRED COMPONENTS system filesystem)
+find_library(SSL_LIB libssl.a REQUIRED)
+find_library(CRYPTO_LIB libcrypto.a REQUIRED)
+
+include_directories(${cpprestsdk_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+set(LIBS ${LIBS} ${cpprestsdk_LIBRARIES} ${Boost_LIBRARIES} ${SSL_LIB} ${CRYPTO_LIB} ${CMAKE_DL_LIBS})
 
 set(SOURCE_FILES client.cpp REST/client.cpp REST/REST.cpp)
 
@@ -11,4 +15,7 @@ else()
 endif()
 
 target_include_directories(disccord PUBLIC ../include)
-target_link_libraries(disccord ${LIBS})
+
+add_executable(letestty disccord.cpp)
+
+target_link_libraries(letestty ${LIBS} disccord)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,6 +16,11 @@ endif()
 
 target_include_directories(disccord PUBLIC ../include)
 
-add_executable(letestty disccord.cpp)
+## For shared builds
+set_target_properties(disccord PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-target_link_libraries(letestty ${LIBS} disccord)
+target_link_libraries(disccord ${LIBS})
+
+install(TARGETS disccord DESTINATION /usr/local/lib)
+
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+find_package (Boost COMPONENTS system filesystem unit_test_framework REQUIRED)
+include_directories (${TEST_SOURCE_DIR}/lib ${Boost_INCLUDE_DIRS})
+add_definitions (-DBOOST_TEST_DYN_LINK)
+add_executable (DisccordTest disccord_test.cpp)
+set_target_properties(disccord PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_link_libraries (DisccordTest disccord ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} 
+						${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})

--- a/tests/disccord_test.cpp
+++ b/tests/disccord_test.cpp
@@ -1,0 +1,10 @@
+/***
+DISCCORD LIB - UNIT TEST
+***/
+
+int main(){
+	
+	//testing here...
+	
+	return 0;
+}


### PR DESCRIPTION
***A proposal for the build structure.*** What these changes will do:

Running `cmake .`:

- Will now include a unit test framework from boost, and adds another cmake config in a new folder: **root**/tests

Running `make`:

- Will be the lib(s) as normal, but now also builds an executable for the lib(s). This is meant for the place to test the lib(s) functionality. It gets put in **root**/tests. 

Running `make install`:

- Will install the lib(s) to a standard location, /usr/local/lib. Currently there is **no install config**, an updateto the cmake will be to have a flag letting the user choose either Debug or Release mode.

Running `make test`:

- Will walk through each of the unit tests for the libs (with the executable(s) we made earlier). This framework shows time for each test, total time, a pass/fail state for each test, % passed, and how many failed out of total tests.


So that's what I've got going. Let me know if you think it is a good start, or should be modified a bit. Or if you completely hate it. 😄 

*note: if you do like it please don't merge yet, few more things I'd like to add (like an actual unit test) before it's merge-worthy*
