### PR TITLE
Handle Empty API Responses, Start on Channel API

### DIFF
--- a/include/models/channel.hpp
+++ b/include/models/channel.hpp
@@ -25,7 +25,7 @@ namespace disccord
                 util::optional<uint32_t> get_bitrate();
                 util::optional<uint32_t> get_user_limit();
                 util::optional<std::string> get_name();
-                util::optional<std::string> get_type();
+                util::optional<uint8_t> get_type();
                 util::optional<std::string> get_topic();
                 util::optional<bool> get_is_private();
                 util::optional<user> get_recipient();
@@ -37,7 +37,8 @@ namespace disccord
             private:
                 util::optional<uint64_t> guild_id, last_message_id;
                 util::optional<uint32_t> position, bitrate, user_limit;
-                util::optional<std::string> name, type, topic;
+                util::optional<uint8_t> type;
+                util::optional<std::string> name, topic;
                 util::optional<bool> is_private;
                 util::optional<user> recipient;
                 util::optional<std::vector<overwrite>> permission_overwrites;

--- a/include/rest/api_client.hpp
+++ b/include/rest/api_client.hpp
@@ -95,7 +95,6 @@ namespace disccord
                     std::string token;
                     disccord::token_type token_type;
                     void setup_discord_handler();
-                    void set_content_length(uint64_t length);
 
                     template <typename TResponse>
                     pplx::task<TResponse> request_json(route_info& route, const pplx::cancellation_token& token = pplx::cancellation_token::none())
@@ -130,8 +129,10 @@ namespace disccord
 
                     pplx::task<void> request_empty(route_info& route, const pplx::cancellation_token& token = pplx::cancellation_token::none())
                     {
-                        set_content_length(0);
-                        return request_internal(route, token).then([](web::http::http_response response){});
+                        disccord::api::request_info* info = new disccord::api::request_info();
+                        
+                        info->set_body("", "application/json");
+                        return request_internal(route, info, token).then([](web::http::http_response response){});
                     }
                     
                     template <typename TModel>
@@ -140,7 +141,6 @@ namespace disccord
                         disccord::api::request_info* info = new disccord::api::request_info();
 
                         info->set_body(body.encode());
-                        set_content_length(info->get_body().size());
                         return request_internal(route, info, token).then([](web::http::http_response response){});
                     }
                     

--- a/include/rest/models/create_message_args.hpp
+++ b/include/rest/models/create_message_args.hpp
@@ -1,0 +1,31 @@
+#ifndef _create_message_args_hpp_
+#define _create_message_args_hpp_
+
+#include <models/model.hpp>
+#include <models/embed.hpp>
+
+namespace disccord
+{
+    namespace rest
+    {
+        namespace models
+        {
+            class create_message_args : public disccord::models::model
+            {
+                public:
+                    create_message_args(std::string content);
+                    virtual ~create_message_args();
+
+                    std::string get_content();
+
+                protected:
+                    virtual void encode_to(std::unordered_map<std::string, web::json::value>& info) override;
+
+                private:
+                    std::string content;
+            };
+        }
+    }
+}
+
+#endif /* _create_message_args_hpp_ */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,7 +21,8 @@ models/integration_account.cpp models/integration.cpp models/channel.cpp
 models/overwrite.cpp models/connection.cpp models/game.cpp models/presence.cpp
 models/guild_embed.cpp models/guild_member.cpp models/read_state.cpp
 models/relationship.cpp models/ban.cpp models/application.cpp
-rest/models/create_dm_channel_args.cpp rest/models/create_group_dm_args.cpp)
+rest/models/create_dm_channel_args.cpp rest/models/create_group_dm_args.cpp
+rest/models/create_message_args.cpp)
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 

--- a/lib/models/channel.cpp
+++ b/lib/models/channel.cpp
@@ -9,7 +9,7 @@ namespace disccord
         channel::channel()
             : entity(), guild_id(), last_message_id(),
             position(), bitrate(), user_limit(),
-            name(), type(), topic(),
+            type(), name(), topic(),
             is_private(),  recipient(), permission_overwrites()
         { }
 
@@ -76,7 +76,7 @@ namespace disccord
             get_field(user_limit, as_integer);
             get_field(bitrate, as_integer);
             get_field(name, as_string);
-            get_field(type, as_string);
+            get_field(type, as_integer);
             get_field(topic, as_string);
             get_field(is_private, as_bool);
             get_composite_field(recipient, user);

--- a/lib/rest/api_client.cpp
+++ b/lib/rest/api_client.cpp
@@ -197,15 +197,6 @@ namespace disccord
                     return pipeline->propagate(req);
                 });
             }
-            
-            void rest_api_client::set_content_length(uint64_t length)
-            {
-                http_client.add_handler([=](auto req, auto pipeline)
-                {
-                    req.headers().set_content_length(length);    
-                    return pipeline->propagate(req);
-                });
-            }
         }
     }
 }

--- a/lib/rest/models/create_message_args.cpp
+++ b/lib/rest/models/create_message_args.cpp
@@ -1,0 +1,27 @@
+#include <rest/models/create_message_args.hpp>
+
+namespace disccord
+{
+    namespace rest
+    {
+        namespace models
+        {
+            create_message_args::create_message_args(std::string _content)
+                : content(_content)
+            { }
+
+            create_message_args::~create_message_args()
+            { }
+
+            void create_message_args::encode_to(std::unordered_map<std::string, web::json::value>& info)
+            {
+                info["content"] = web::json::value(get_content());
+            }
+
+            std::string create_message_args::get_content()
+            {
+                return content;
+            }
+        }
+    }
+}

--- a/tests/models.cpp
+++ b/tests/models.cpp
@@ -332,7 +332,7 @@ TEST_CASE( "Channel model correctly instantiated" ){
     "id": "41771983423143937",
     "guild_id": "41771983423143937",
     "name": "general",
-    "type": "text",
+    "type": 0,
     "position": 6,
     "is_private": false,
     "permission_overwrites": [
@@ -360,7 +360,7 @@ TEST_CASE( "Channel model correctly instantiated" ){
     REQUIRE(test_channel2.get_last_message_id().get_value() == 155117677105512449);
     REQUIRE(test_channel2.get_topic().get_value() == "24/7 chat about how to gank Mike #2");
     REQUIRE(test_channel2.get_position().get_value() == 6);
-    REQUIRE(test_channel2.get_type().get_value() == "text");
+    REQUIRE(test_channel2.get_type().get_value() == 0);
     REQUIRE(test_channel2.get_name().get_value() == "general");
     REQUIRE(test_channel2.get_guild_id().get_value() == 41771983423143937);
     
@@ -381,7 +381,7 @@ TEST_CASE( "Channel model correctly instantiated" ){
     "id": "155101607195836416",
     "guild_id": "41771983423143937",
     "name": "ROCKET CHEESE",
-    "type": "voice",
+    "type": 1,
     "position": 5,
     "is_private": false,
     "permission_overwrites": [],
@@ -396,7 +396,7 @@ TEST_CASE( "Channel model correctly instantiated" ){
     REQUIRE(test_channel3.get_bitrate().get_value() == 64000);
     REQUIRE(test_channel3.get_user_limit().get_value() == 0);
     REQUIRE(test_channel3.get_position().get_value() == 5);
-    REQUIRE(test_channel3.get_type().get_value() == "voice");
+    REQUIRE(test_channel3.get_type().get_value() == 1);
     REQUIRE(test_channel3.get_name().get_value() == "ROCKET CHEESE");
     REQUIRE(test_channel3.get_guild_id().get_value() == 41771983423143937);
 }
@@ -654,7 +654,7 @@ TEST_CASE( "Guild model correctly instantiated" ){
                 "id": "41771983423143937",
                 "guild_id": "41771983423143937",
                 "name": "general",
-                "type": "text",
+                "type": 0,
                 "position": 6,
                 "is_private": false,
                 "permission_overwrites": [],
@@ -665,7 +665,7 @@ TEST_CASE( "Guild model correctly instantiated" ){
                 "id": "41771983423143937",
                 "guild_id": "41771983423143937",
                 "name": "general",
-                "type": "text",
+                "type": 0,
                 "position": 6,
                 "is_private": false,
                 "permission_overwrites": [],


### PR DESCRIPTION
 just a bit of cleanup as well in regards to the channel object. but empty request/responses should be good for now (refactor it as you see fit). if you dont want any changes, can merge this one in right away