### PR TITLE
Avatar Features

### DIFF
--- a/include/disccord/models/user.hpp
+++ b/include/disccord/models/user.hpp
@@ -18,18 +18,19 @@ namespace disccord
                 std::string get_username();
                 uint16_t get_discriminator();
                 util::optional<std::string> get_avatar();
-                util::optional<std::string> get_avatar_url();
                 bool get_bot();
                 util::optional<bool> get_mfa_enabled();
                 util::optional<bool> get_verified();
                 util::optional<std::string> get_email();
+                
+                util::optional<std::string> get_avatar_url();
 
             protected:
                 virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
 
             private:
                 std::string username;
-                util::optional<std::string> avatar, email, avatar_url;
+                util::optional<std::string> avatar, email;
                 uint16_t discriminator;
                 bool bot;
                 util::optional<bool> mfa_enabled, verified;

--- a/include/disccord/models/user.hpp
+++ b/include/disccord/models/user.hpp
@@ -18,6 +18,7 @@ namespace disccord
                 std::string get_username();
                 uint16_t get_discriminator();
                 util::optional<std::string> get_avatar();
+                util::optional<std::string> get_avatar_url();
                 bool get_bot();
                 util::optional<bool> get_mfa_enabled();
                 util::optional<bool> get_verified();
@@ -28,7 +29,7 @@ namespace disccord
 
             private:
                 std::string username;
-                util::optional<std::string> avatar, email;
+                util::optional<std::string> avatar, email, avatar_url;
                 uint16_t discriminator;
                 bool bot;
                 util::optional<bool> mfa_enabled, verified;

--- a/include/disccord/rest/api_client.hpp
+++ b/include/disccord/rest/api_client.hpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include <cpprest/http_client.h>
+#include <cpprest/filestream.h>
 
 #include <disccord/api/bucket_info.hpp>
 #include <disccord/api/multipart_request.hpp>

--- a/include/disccord/rest/models/modify_current_user_args.hpp
+++ b/include/disccord/rest/models/modify_current_user_args.hpp
@@ -1,13 +1,11 @@
 #ifndef _modify_current_user_args_hpp_
 #define _modify_current_user_args_hpp_
 
-#include <cpprest/http_client.h>
+#include <cpprest/streams.h>
+#include <cpprest/containerstream.h>
 
 #include <disccord/models/model.hpp>
 #include <disccord/util/optional.hpp>
-
-using namespace Concurrency::streams;
-using namespace utility::conversions;
 
 namespace disccord
 {
@@ -22,9 +20,7 @@ namespace disccord
                     virtual ~modify_current_user_args();
 
                     void set_name(std::string name);
-                    //avatar_stream -> file_stream<unsigned char>::open_istream(<filename>).get()
-                    //NOTE: using an unsigned char stream because the to_base64 method takes a std::vector<unsigned char>
-                    void set_avatar(basic_istream<unsigned char> avatar_stream);
+                    void set_avatar(concurrency::streams::basic_istream<unsigned char> avatar_stream);
 
                 protected:
                     virtual void encode_to(std::unordered_map<std::string, web::json::value>& info) override;

--- a/include/disccord/rest/models/modify_current_user_args.hpp
+++ b/include/disccord/rest/models/modify_current_user_args.hpp
@@ -1,8 +1,13 @@
 #ifndef _modify_current_user_args_hpp_
 #define _modify_current_user_args_hpp_
 
+#include <cpprest/http_client.h>
+
 #include <disccord/models/model.hpp>
 #include <disccord/util/optional.hpp>
+
+using namespace Concurrency::streams;
+using namespace utility::conversions;
 
 namespace disccord
 {
@@ -17,13 +22,15 @@ namespace disccord
                     virtual ~modify_current_user_args();
 
                     void set_name(std::string name);
-                    void set_avatar(std::string avatar);
+                    //avatar_stream -> file_stream<unsigned char>::open_istream(<filename>).get()
+                    //NOTE: using an unsigned char stream because the to_base64 method takes a std::vector<unsigned char>
+                    void set_avatar(basic_istream<unsigned char> avatar_stream);
 
                 protected:
                     virtual void encode_to(std::unordered_map<std::string, web::json::value>& info) override;
 
                 private:
-                    util::optional<std::string> name, avatar; //avatar must be passed image data converted to base64 data
+                    util::optional<std::string> name, avatar;
             };
         }
     }

--- a/lib/models/user.cpp
+++ b/lib/models/user.cpp
@@ -43,7 +43,7 @@ namespace disccord
             
             if (get_avatar().is_specified())
             {
-                std::string url = "https://images.discordapp.net/avatars/"+std::to_string(get_id())+"/"+get_avatar().get_value()+".png?size=1024";
+                std::string url = "https://cdn.discordapp.com/avatars/"+std::to_string(get_id())+"/"+get_avatar().get_value()+".png?size=1024";
                 avatar_url = util::optional<std::string>(url);
             }
             else

--- a/lib/models/user.cpp
+++ b/lib/models/user.cpp
@@ -7,8 +7,8 @@ namespace disccord
     namespace models
     {
         user::user()
-            : username(""), avatar(), email(), discriminator(0),
-            bot(false), mfa_enabled(), verified()
+            : username(""), avatar(), email(), avatar_url(), 
+            discriminator(0), bot(false), mfa_enabled(), verified()
         { }
 
         user::~user()
@@ -40,6 +40,14 @@ namespace disccord
             get_field(mfa_enabled, as_bool);
             get_field(verified, as_bool);
             get_field(email, as_string);
+            
+            if (get_avatar().is_specified())
+            {
+                std::string url = "https://images.discordapp.net/avatars/"+std::to_string(get_id())+"/"+get_avatar().get_value()+".png?size=1024";
+                avatar_url = util::optional<std::string>(url);
+            }
+            else
+                avatar_url = util::optional<std::string>::no_value();
 
             #undef get_field
         }
@@ -69,6 +77,7 @@ namespace disccord
         define_get_method(username)
         define_get_method(discriminator)
         define_get_method(avatar)
+        define_get_method(avatar_url)
         define_get_method(bot)
         define_get_method(mfa_enabled)
         define_get_method(verified)

--- a/lib/models/user.cpp
+++ b/lib/models/user.cpp
@@ -7,8 +7,8 @@ namespace disccord
     namespace models
     {
         user::user()
-            : username(""), avatar(), email(), avatar_url(), 
-            discriminator(0), bot(false), mfa_enabled(), verified()
+            : username(""), avatar(), email(), discriminator(0),
+            bot(false), mfa_enabled(), verified()
         { }
 
         user::~user()
@@ -40,14 +40,6 @@ namespace disccord
             get_field(mfa_enabled, as_bool);
             get_field(verified, as_bool);
             get_field(email, as_string);
-            
-            if (get_avatar().is_specified())
-            {
-                std::string url = "https://cdn.discordapp.com/avatars/"+std::to_string(get_id())+"/"+get_avatar().get_value()+".png?size=1024";
-                avatar_url = util::optional<std::string>(url);
-            }
-            else
-                avatar_url = util::optional<std::string>::no_value();
 
             #undef get_field
         }
@@ -77,11 +69,21 @@ namespace disccord
         define_get_method(username)
         define_get_method(discriminator)
         define_get_method(avatar)
-        define_get_method(avatar_url)
         define_get_method(bot)
         define_get_method(mfa_enabled)
         define_get_method(verified)
         define_get_method(email)
+        
+        util::optional<std::string> user::get_avatar_url()
+        {
+            if (get_avatar().is_specified())
+            {
+                std::string url = "https://cdn.discordapp.com/avatars/"+std::to_string(get_id())+"/"+get_avatar().get_value()+".png?size=1024";
+                return util::optional<std::string>(url);
+            }
+            else
+                return util::optional<std::string>::no_value();
+        }
 
         #undef define_get_method
     }

--- a/lib/rest/models/modify_current_user_args.cpp
+++ b/lib/rest/models/modify_current_user_args.cpp
@@ -31,14 +31,14 @@ namespace disccord
 
             define_set_method(name, std::string)
             
-            void modify_current_user_args::set_avatar(basic_istream<unsigned char> avatar_stream)
+            void modify_current_user_args::set_avatar(concurrency::streams::basic_istream<unsigned char> avatar_stream)
             {
-                container_buffer<std::vector<unsigned char>> stream_buffer;
+                concurrency::streams::container_buffer<std::vector<unsigned char>> stream_buffer;
                 avatar_stream.read_to_end(stream_buffer).get();
                 auto stream_bytes = std::move(stream_buffer.collection());
                 avatar_stream.close();
                 stream_buffer.close();
-                std::string avatar_body = "data:image/jpeg;base64," + to_base64(stream_bytes);
+                std::string avatar_body = "data:image/jpeg;base64," + utility::conversions::to_base64(stream_bytes);
                 avatar = util::optional<std::string>(avatar_body);
             }
 

--- a/lib/rest/models/modify_current_user_args.cpp
+++ b/lib/rest/models/modify_current_user_args.cpp
@@ -30,7 +30,17 @@ namespace disccord
                 }
 
             define_set_method(name, std::string)
-            define_set_method(avatar, std::string)
+            
+            void modify_current_user_args::set_avatar(basic_istream<unsigned char> avatar_stream)
+            {
+                container_buffer<std::vector<unsigned char>> stream_buffer;
+                avatar_stream.read_to_end(stream_buffer).get();
+                auto stream_bytes = std::move(stream_buffer.collection());
+                avatar_stream.close();
+                stream_buffer.close();
+                std::string avatar_body = "data:image/jpeg;base64," + to_base64(stream_bytes);
+                avatar = util::optional<std::string>(avatar_body);
+            }
 
             #undef define_set_method
         }

--- a/lib/rest/models/modify_current_user_args.cpp
+++ b/lib/rest/models/modify_current_user_args.cpp
@@ -36,7 +36,6 @@ namespace disccord
                 concurrency::streams::container_buffer<std::vector<unsigned char>> stream_buffer;
                 avatar_stream.read_to_end(stream_buffer).get();
                 auto stream_bytes = std::move(stream_buffer.collection());
-                avatar_stream.close();
                 stream_buffer.close();
                 std::string avatar_body = "data:image/jpeg;base64," + utility::conversions::to_base64(stream_bytes);
                 avatar = util::optional<std::string>(avatar_body);


### PR DESCRIPTION
A few feature additions related to avatars:

- [x] configure avatar data to be read in from stream when user wants to update their avatar

current usage:
```cpp
using namespace concurrency::streams;

//file_stream comes included from disccord/rest/api_client.hpp
//using unsigned char stream bcuz the base64 conversion method takes a std::vector<unsigned char>
auto image_stream = file_stream<unsigned char>::open_istream("path/to/file.jpg").get();
modify_current_user_args args;
args.set_avatar(image_stream);
```
current thoughts:
- want to play with this impl a little bit, open to suggestions

- [x] add a method to `models::user` that gets the avatar URL pre-built based on hash and user id.
```cpp
//something like this
auto usr = client.get_current_user().get();
create_message_args args(usr.get_avatar_url().get_value());
client.create_message(<chan_id>, args);
```
current thoughts:
- could let user specify format (jpg/png) and size, but for now will just default


UPDATE: Both additions have been tested and are working fine