### PR TITLE
General API Bug Fixes

### DIFF
--- a/include/disccord/models/relationship.hpp
+++ b/include/disccord/models/relationship.hpp
@@ -18,14 +18,14 @@ namespace disccord
                 virtual void decode(web::json::value json) override;
 
                 util::optional<models::user> get_user();
-                util::optional<uint32_t> get_type();
+                util::optional<relationship_type> get_type();
 
             protected:
                 virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
 
             private:
                 util::optional<models::user> user;
-                util::optional<uint32_t> type;
+                util::optional<relationship_type> type;
         };
     }
 }

--- a/include/disccord/models/user.hpp
+++ b/include/disccord/models/user.hpp
@@ -18,7 +18,7 @@ namespace disccord
                 std::string get_username();
                 uint16_t get_discriminator();
                 util::optional<std::string> get_avatar();
-                bool get_bot();
+                util::optional<bool> get_bot();
                 util::optional<bool> get_mfa_enabled();
                 util::optional<bool> get_verified();
                 util::optional<std::string> get_email();
@@ -32,8 +32,7 @@ namespace disccord
                 std::string username;
                 util::optional<std::string> avatar, email;
                 uint16_t discriminator;
-                bool bot;
-                util::optional<bool> mfa_enabled, verified;
+                util::optional<bool> bot, mfa_enabled, verified;
         };
     }
 }

--- a/include/disccord/models/user_guild.hpp
+++ b/include/disccord/models/user_guild.hpp
@@ -16,7 +16,7 @@ namespace disccord
                 virtual void decode(web::json::value json) override;
 
                 std::string get_name();
-                std::string get_icon();
+                util::optional<std::string> get_icon();
                 bool get_owner();
                 int64_t get_id();
                 int64_t get_permissions();
@@ -25,7 +25,8 @@ namespace disccord
                 virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
 
             private:
-                std::string name, icon;
+                std::string name;
+                util::optional<std::string> icon;
                 bool owner;
                 int64_t id, permissions;
         };

--- a/include/disccord/models/webhook.hpp
+++ b/include/disccord/models/webhook.hpp
@@ -1,0 +1,39 @@
+#ifndef _webhook_hpp_
+#define _webhook_hpp_
+
+#include <disccord/models/entity.hpp>
+#include <disccord/models/user.hpp>
+
+namespace disccord
+{
+    namespace models
+    {
+        class webhook : public entity
+        {
+            public:
+                webhook();
+                virtual ~webhook();
+
+                virtual void decode(web::json::value json) override;
+
+                util::optional<uint64_t> get_guild_id();
+                uint64_t get_channel_id();
+                util::optional<models::user> get_user();
+                util::optional<std::string> get_name();
+                util::optional<std::string> get_avatar();
+                std::string get_token();
+
+            protected:
+                virtual void encode_to(std::unordered_map<std::string,web::json::value> &info) override;
+
+            private:
+                util::optional<uint64_t> guild_id;
+                uint64_t channel_id;
+                util::optional<models::user> user;
+                util::optional<std::string> name, avatar;
+                std::string token;
+        };
+    }
+}
+
+#endif /* _webhook_hpp_ */

--- a/include/disccord/rest/api_client.hpp
+++ b/include/disccord/rest/api_client.hpp
@@ -238,10 +238,6 @@ namespace disccord
 
                     pplx::task<disccord::models::webhook> execute_webhook(uint64_t webhook_id, std::string webhook_token, disccord::rest::models::execute_webhook_args args, bool wait = false, const pplx::cancellation_token& token = pplx::cancellation_token::none());
 
-                    pplx::task<disccord::models::webhook> execute_slack_webhook(uint64_t webhook_id, std::string webhook_token, bool wait = true, const pplx::cancellation_token& token = pplx::cancellation_token::none());
-
-                    pplx::task<disccord::models::webhook> execute_github_webhook(uint64_t webhook_id, std::string webhook_token, bool wait = true, const pplx::cancellation_token& token = pplx::cancellation_token::none());
-
                 private:
                     pplx::task<void> request_empty_internal(route_info& route, const pplx::cancellation_token& token = pplx::cancellation_token::none());
                     pplx::task<void> request_empty_internal(route_info& route, disccord::api::request_info* request, const pplx::cancellation_token& token = pplx::cancellation_token::none());

--- a/include/disccord/rest/api_client.hpp
+++ b/include/disccord/rest/api_client.hpp
@@ -225,6 +225,7 @@ namespace disccord
                     std::string token;
                     disccord::token_type token_type;
                     void setup_discord_handler();
+                    std::string urlencode(const std::string s);
 
                     pplx::task<void> request(route_info& route, const pplx::cancellation_token& token = pplx::cancellation_token::none());
 

--- a/include/disccord/rest/api_client.hpp
+++ b/include/disccord/rest/api_client.hpp
@@ -225,7 +225,7 @@ namespace disccord
                     std::string token;
                     disccord::token_type token_type;
                     void setup_discord_handler();
-                    std::string urlencode(const std::string s);
+                    std::string url_encode(const std::string s);
 
                     pplx::task<void> request(route_info& route, const pplx::cancellation_token& token = pplx::cancellation_token::none());
 

--- a/include/disccord/rest/api_client.hpp
+++ b/include/disccord/rest/api_client.hpp
@@ -25,6 +25,7 @@
 #include <disccord/models/user.hpp>
 #include <disccord/models/user_guild.hpp>
 #include <disccord/models/voice_region.hpp>
+#include <disccord/models/webhook.hpp>
 
 #include <disccord/rest/models/guild_prune.hpp>
 #include <disccord/rest/models/nickname.hpp>
@@ -40,6 +41,9 @@
 #include <disccord/rest/models/modify_guild_member_args.hpp>
 #include <disccord/rest/models/modify_positions_args.hpp>
 #include <disccord/rest/models/modify_current_user_args.hpp>
+#include <disccord/rest/models/execute_webhook_args.hpp>
+#include <disccord/rest/models/create_webhook_args.hpp>
+#include <disccord/rest/models/modify_webhook_args.hpp>
 
 namespace disccord
 {
@@ -212,6 +216,31 @@ namespace disccord
 
                     // Voice API
                     pplx::task<std::vector<disccord::models::voice_region>> list_voice_regions(const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    // Webhook API
+                    pplx::task<disccord::models::webhook> create_webhook(uint64_t channel_id, disccord::rest::models::create_webhook_args args, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<std::vector<disccord::models::webhook>> get_channel_webhooks(uint64_t channel_id, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<std::vector<disccord::models::webhook>> get_guild_webhooks(uint64_t guild_id, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<disccord::models::webhook> get_webhook(uint64_t webhook_id, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<disccord::models::webhook> get_webhook_token(uint64_t webhook_id, std::string webhook_token, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<disccord::models::webhook> modify_webhook(uint64_t webhook_id, disccord::rest::models::modify_webhook_args args, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<disccord::models::webhook> modify_webhook_token(uint64_t webhook_id, std::string webhook_token, disccord::rest::models::modify_webhook_args args, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<void> delete_webhook(uint64_t webhook_id, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<void> delete_webhook_token(uint64_t webhook_id, std::string webhook_token, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<disccord::models::webhook> execute_webhook(uint64_t webhook_id, std::string webhook_token, disccord::rest::models::execute_webhook_args args, bool wait = false, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<disccord::models::webhook> execute_slack_webhook(uint64_t webhook_id, std::string webhook_token, bool wait = true, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<disccord::models::webhook> execute_github_webhook(uint64_t webhook_id, std::string webhook_token, bool wait = true, const pplx::cancellation_token& token = pplx::cancellation_token::none());
 
                 private:
                     pplx::task<void> request_empty_internal(route_info& route, const pplx::cancellation_token& token = pplx::cancellation_token::none());

--- a/include/disccord/rest/models/create_webhook_args.hpp
+++ b/include/disccord/rest/models/create_webhook_args.hpp
@@ -1,0 +1,36 @@
+#ifndef _create_webhook_args_hpp_
+#define _create_webhook_args_hpp_
+
+#include <cpprest/streams.h>
+#include <cpprest/containerstream.h>
+
+#include <disccord/models/model.hpp>
+#include <disccord/util/optional.hpp>
+
+namespace disccord
+{
+    namespace rest
+    {
+        namespace models
+        {
+            class create_webhook_args : public disccord::models::model
+            {
+                public:
+                    create_webhook_args(std::string name);
+                    virtual ~create_webhook_args();
+
+                    void set_name(std::string name);
+                    void set_avatar(concurrency::streams::basic_istream<unsigned char> avatar_stream);
+
+                protected:
+                    virtual void encode_to(std::unordered_map<std::string, web::json::value>& info) override;
+
+                private:
+                    std::string name;
+                    util::optional<std::string> avatar;
+            };
+        }
+    }
+}
+
+#endif /* _create_webhook_args_hpp_ */

--- a/include/disccord/rest/models/execute_webhook_args.hpp
+++ b/include/disccord/rest/models/execute_webhook_args.hpp
@@ -1,0 +1,37 @@
+#ifndef _execute_webhook_args_hpp_
+#define _execute_webhook_args_hpp_
+
+#include <disccord/models/model.hpp>
+#include <disccord/models/embed.hpp>
+#include <disccord/util/optional.hpp>
+
+namespace disccord
+{
+    namespace rest
+    {
+        namespace models
+        {
+            class execute_webhook_args : public disccord::models::model
+            {
+                public:
+                    execute_webhook_args(std::string content);
+                    execute_webhook_args(std::vector<disccord::models::embed> embeds);
+                    virtual ~execute_webhook_args();
+
+                    void set_username(std::string username);
+                    void set_avatar_url(std::string avatar_url);
+                    void set_tts(bool tts);
+
+                protected:
+                    virtual void encode_to(std::unordered_map<std::string, web::json::value>& info) override;
+
+                private:
+                    util::optional<std::string> content, username, avatar_url;
+                    util::optional<bool> tts;
+                    util::optional<std::vector<disccord::models::embed>> embeds;
+            };
+        }
+    }
+}
+
+#endif /* _execute_webhook_args_hpp_ */

--- a/include/disccord/rest/models/modify_webhook_args.hpp
+++ b/include/disccord/rest/models/modify_webhook_args.hpp
@@ -1,0 +1,35 @@
+#ifndef _modify_webhook_args_hpp_
+#define _modify_webhook_args_hpp_
+
+#include <cpprest/streams.h>
+#include <cpprest/containerstream.h>
+
+#include <disccord/models/model.hpp>
+#include <disccord/util/optional.hpp>
+
+namespace disccord
+{
+    namespace rest
+    {
+        namespace models
+        {
+            class modify_webhook_args : public disccord::models::model
+            {
+                public:
+                    modify_webhook_args();
+                    virtual ~modify_webhook_args();
+
+                    void set_name(std::string name);
+                    void set_avatar(concurrency::streams::basic_istream<unsigned char> avatar_stream);
+
+                protected:
+                    virtual void encode_to(std::unordered_map<std::string, web::json::value>& info) override;
+
+                private:
+                    util::optional<std::string> name, avatar;
+            };
+        }
+    }
+}
+
+#endif /* _modify_webhook_args_hpp_ */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,7 +16,7 @@ models/embed_footer.cpp models/embed_image.cpp models/embed_provider.cpp
 models/embed_thumbnail.cpp models/embed_video.cpp models/guild.cpp
 models/invite.cpp models/invite_channel.cpp models/invite_guild.cpp
 models/invite_metadata.cpp models/attachment.cpp models/emoji.cpp
-models/reaction.cpp models/role.cpp models/message.cpp
+models/reaction.cpp models/role.cpp models/message.cpp models/webhook.cpp
 models/integration_account.cpp models/integration.cpp models/channel.cpp
 models/overwrite.cpp models/connection.cpp models/game.cpp models/presence.cpp
 models/guild_embed.cpp models/guild_member.cpp models/read_state.cpp models/relationship.cpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -31,7 +31,9 @@ rest/models/modify_guild_member_args.cpp rest/models/guild_role_args.cpp
 rest/models/modify_guild_embed_args.cpp rest/models/modify_channel_args.cpp
 rest/models/edit_message_args.cpp rest/models/bulk_delete_message_args.cpp
 rest/models/edit_channel_permissions_args.cpp rest/models/create_channel_invite_args.cpp
-rest/models/add_dm_recipient_args.cpp rest/models/modify_current_user_args.cpp)
+rest/models/add_dm_recipient_args.cpp rest/models/modify_current_user_args.cpp
+rest/models/execute_webhook_args.cpp rest/models/create_webhook_args.cpp
+rest/models/modify_webhook_args.cpp)
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 

--- a/lib/models/user.cpp
+++ b/lib/models/user.cpp
@@ -8,7 +8,7 @@ namespace disccord
     {
         user::user()
             : username(""), avatar(), email(), discriminator(0),
-            bot(false), mfa_enabled(), verified()
+            bot(), mfa_enabled(), verified()
         { }
 
         user::~user()
@@ -35,8 +35,7 @@ namespace disccord
                 }
 
             get_field(avatar, as_string);
-            bot = json.at("bot").as_bool();
-            //get_field(bot, as_bool);
+            get_field(bot, as_bool);
             get_field(mfa_enabled, as_bool);
             get_field(verified, as_bool);
             get_field(email, as_string);
@@ -52,7 +51,8 @@ namespace disccord
             info["discriminator"] = web::json::value(std::to_string(get_discriminator()));
             if (get_avatar().is_specified())
                 info["avatar"] = get_avatar();
-            info["bot"] = web::json::value(get_bot());
+            if (get_bot().is_specified())
+                info["bot"] = get_bot();
             if (get_mfa_enabled().is_specified())
                 info["mfa_enabled"] = get_mfa_enabled();
             if (get_verified().is_specified())

--- a/lib/models/webhook.cpp
+++ b/lib/models/webhook.cpp
@@ -1,0 +1,99 @@
+#include <string>
+
+#include <disccord/models/webhook.hpp>
+
+namespace disccord
+{
+    namespace models
+    {
+        webhook::webhook()
+            : entity(), guild_id(), channel_id(0),
+            user(), name(), avatar(), token("")
+        { }
+
+        webhook::~webhook()
+        { }
+
+        void webhook::decode(web::json::value json)
+        {
+            entity::decode(json);
+
+            channel_id = std::stoull(json.at("channel_id").as_string());
+            token = json.at("token").as_string();
+
+            #define get_field(var, conv) \
+                if (json.has_field(#var)) { \
+                    auto field = json.at(#var); \
+                    if (!field.is_null()) { \
+                        var = decltype(var)(field.conv()); \
+                    } else { \
+                        var = decltype(var)::no_value(); \
+                    } \
+                } else { \
+                    var = decltype(var)(); \
+                }
+            #define get_id_field(var) \
+                if (json.has_field(#var)) { \
+                    auto field = json.at(#var); \
+                    if (!field.is_null()) { \
+                        var = decltype(var)(std::stoull(field.as_string())); \
+                    } else { \
+                        var = decltype(var)::no_value(); \
+                    } \
+                } else { \
+                    var = decltype(var)(); \
+                }
+
+            get_field(name, as_string);
+            get_field(avatar, as_string);
+            get_id_field(guild_id);
+
+            if (json.has_field("user")) {
+                auto field = json.at("user");
+                if (!field.is_null()) {
+                    models::user val;
+                    val.decode(field);
+                    user = util::optional<models::user>(val);
+                } else {
+                    user = util::optional<models::user>::no_value();
+                }
+            }
+            else {
+                user = util::optional<models::user>();
+            }
+
+            #undef get_field
+            #undef get_id_field
+        }
+
+        void webhook::encode_to(std::unordered_map<std::string,web::json::value> &info)
+        {
+            entity::encode_to(info);
+
+            info["channel_id"] = web::json::value(get_channel_id());
+            info["token"] = web::json::value(get_token());
+            if (get_name().is_specified())
+                info["name"] = get_name();
+            if (get_avatar().is_specified())
+                info["avatar"] = get_avatar();
+            if (get_guild_id().is_specified())
+                info["guild_id"] = get_guild_id();
+            if (user.is_specified())
+                info["user"] = user.get_value().encode();
+        }
+
+        #define define_get_method(field_name) \
+            decltype(webhook::field_name) webhook::get_##field_name() { \
+                return field_name; \
+            }
+
+        define_get_method(guild_id)
+        define_get_method(channel_id)
+        define_get_method(user)
+        define_get_method(name)
+        define_get_method(avatar)
+        define_get_method(token)
+
+        #undef define_get_method
+    }
+}

--- a/lib/rest/api_client.cpp
+++ b/lib/rest/api_client.cpp
@@ -586,6 +586,82 @@ namespace disccord
                 return request_multi_json<disccord::models::voice_region>(route, token);
             }
 
+            // Webhook API
+            pplx::task<disccord::models::webhook> rest_api_client::create_webhook(uint64_t channel_id, disccord::rest::models::create_webhook_args args, const pplx::cancellation_token& token)
+            {
+                auto route = get_route("POST", "/channels/{channel.id}/webhooks", std::to_string(channel_id));
+                return request_json<disccord::models::webhook>(route, args, token);
+            }
+
+            pplx::task<std::vector<disccord::models::webhook>> rest_api_client::get_channel_webhooks(uint64_t channel_id, const pplx::cancellation_token& token)
+            {
+                auto route = get_route("GET", "/channels/{channel.id}/webhooks", std::to_string(channel_id));
+                return request_multi_json<disccord::models::webhook>(route, token);
+            }
+
+            pplx::task<std::vector<disccord::models::webhook>> rest_api_client::get_guild_webhooks(uint64_t guild_id, const pplx::cancellation_token& token)
+            {
+                auto route = get_route("GET", "/guilds/{guild.id}/webhooks", std::to_string(guild_id));
+                return request_multi_json<disccord::models::webhook>(route, token);
+            }
+
+            pplx::task<disccord::models::webhook> rest_api_client::get_webhook(uint64_t webhook_id, const pplx::cancellation_token& token)
+            {
+                auto route = get_route("GET", "/webhooks/{webhook.id}", std::to_string(webhook_id));
+                return request_json<disccord::models::webhook>(route, token);
+            }
+
+            pplx::task<disccord::models::webhook> rest_api_client::get_webhook_token(uint64_t webhook_id, std::string webhook_token, const pplx::cancellation_token& token)
+            {
+                auto route = get_route("GET", "/webhooks/{webhook.id}/{webhook.token}", std::to_string(webhook_id), webhook_token);
+                return request_json<disccord::models::webhook>(route, token);
+            }
+
+            pplx::task<disccord::models::webhook> rest_api_client::modify_webhook(uint64_t webhook_id, disccord::rest::models::modify_webhook_args args, const pplx::cancellation_token& token)
+            {
+                auto route = get_route("PATCH", "/webhooks/{webhook.id}", std::to_string(webhook_id));
+                return request_json<disccord::models::webhook>(route, args, token);
+            }
+
+            pplx::task<disccord::models::webhook> rest_api_client::modify_webhook_token(uint64_t webhook_id, std::string webhook_token, disccord::rest::models::modify_webhook_args args, const pplx::cancellation_token& token)
+            {
+                auto route = get_route("PATCH", "/webhooks/{webhook.id}/{webhook.token}", std::to_string(webhook_id), webhook_token);
+                return request_json<disccord::models::webhook>(route, args, token);
+            }
+
+            pplx::task<void> rest_api_client::delete_webhook(uint64_t webhook_id, const pplx::cancellation_token& token)
+            {
+                auto route = get_route("DELETE", "/webhooks/{webhook.id}", std::to_string(webhook_id));
+                return request(route, token);
+            }
+
+            pplx::task<void> rest_api_client::delete_webhook_token(uint64_t webhook_id, std::string webhook_token, const pplx::cancellation_token& token)
+            {
+                auto route = get_route("DELETE", "/webhooks/{webhook.id}/{webhook.token}", std::to_string(webhook_id), webhook_token);
+                return request(route, token);
+            }
+
+            pplx::task<disccord::models::webhook> rest_api_client::execute_webhook(uint64_t webhook_id, std::string webhook_token, disccord::rest::models::execute_webhook_args args, bool wait, const pplx::cancellation_token& token)
+            {
+                std::string wait_val = wait ? "true" : "false";
+                auto route = get_route("POST", "/webhooks/{webhook.id}/{webhook.token}?wait={wait}", std::to_string(webhook_id), webhook_token, wait_val);
+                return request_json<disccord::models::webhook>(route, args, token);
+            }
+
+            pplx::task<disccord::models::webhook> rest_api_client::execute_slack_webhook(uint64_t webhook_id, std::string webhook_token, bool wait, const pplx::cancellation_token& token)
+            {
+                std::string wait_val = wait ? "true" : "false";
+                auto route = get_route("POST", "/webhooks/{webhook.id}/{webhook.token}/slack?wait={wait}", std::to_string(webhook_id), webhook_token, wait_val);
+                return request_json<disccord::models::webhook>(route, token);
+            }
+
+            pplx::task<disccord::models::webhook> rest_api_client::execute_github_webhook(uint64_t webhook_id, std::string webhook_token, bool wait, const pplx::cancellation_token& token)
+            {
+                std::string wait_val = wait ? "true" : "false";
+                auto route = get_route("POST", "/webhooks/{webhook.id}/{webhook.token}/github?wait={wait}", std::to_string(webhook_id), webhook_token, wait_val);
+                return request_json<disccord::models::webhook>(route, token);
+            }
+
             disccord::api::bucket_info* rest_api_client::get_bucket(route_info& info)
             {
                 auto bucket_itr = buckets.find(info.bucket_url);

--- a/lib/rest/api_client.cpp
+++ b/lib/rest/api_client.cpp
@@ -255,25 +255,25 @@ namespace disccord
 
             pplx::task<void> rest_api_client::create_reaction(uint64_t channel_id, uint64_t message_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = get_route("PUT", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me", std::to_string(channel_id), std::to_string(message_id), emoji);
+                auto route = get_route("PUT", "/channels/{channel.id}/messages/{message.id}/reactions/"+urlencode(emoji)+"/@me", std::to_string(channel_id), std::to_string(message_id));
                 return request(route, token);
             }
 
             pplx::task<void> rest_api_client::delete_own_reaction(uint64_t channel_id, uint64_t message_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = get_route("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me", std::to_string(channel_id), emoji, std::to_string(message_id));
+                auto route = get_route("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/"+urlencode(emoji)+"/@me", std::to_string(channel_id), std::to_string(message_id));
                 return request(route, token);
             }
 
             pplx::task<void> rest_api_client::delete_user_reaction(uint64_t channel_id, uint64_t message_id, uint64_t user_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = get_route("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/{user_id}", std::to_string(channel_id), std::to_string(message_id), emoji, std::to_string(user_id));
+                auto route = get_route("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/"+urlencode(emoji)+"/{user_id}", std::to_string(channel_id), std::to_string(message_id), std::to_string(user_id));
                 return request(route, token);
             }
 
             pplx::task<std::vector<disccord::models::user>> rest_api_client::get_reactions(uint64_t channel_id, uint64_t message_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = get_route("GET", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}", std::to_string(channel_id), std::to_string(message_id), emoji);
+                auto route = get_route("GET", "/channels/{channel.id}/messages/{message.id}/reactions/"+urlencode(emoji), std::to_string(channel_id), std::to_string(message_id), emoji);
                 return request_multi_json<disccord::models::user>(route, token);
             }
 
@@ -626,6 +626,31 @@ namespace disccord
                     req.headers().add("Authorization", token_type_s + token);
                     return pipeline->propagate(req);
                 });
+            }
+            
+            std::string rest_api_client::urlencode(const std::string s)
+            {
+                std::string lookup = "0123456789ABCDEF";
+                std::stringstream e;
+                
+                for (const char &c : s) //RFC 3986 section 2.3 Unreserved Characters
+                {
+                    if (('0' <= c && c <= '9') ||
+                        ('a' <= c && c <= 'z') ||
+                        ('A' <= c && c <= 'Z') ||
+                        (c=='-' || c=='_' || c=='.' || c=='~') 
+                    )
+                    {
+                        e << c;
+                    }
+                    else
+                    {
+                        e << '%';
+                        e << lookup[(c & 0xF0) >> 4];
+                        e << lookup[(c & 0x0F)];
+                    }
+                }
+                return e.str();
             }
         }
     }

--- a/lib/rest/api_client.cpp
+++ b/lib/rest/api_client.cpp
@@ -255,25 +255,25 @@ namespace disccord
 
             pplx::task<void> rest_api_client::create_reaction(uint64_t channel_id, uint64_t message_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = get_route("PUT", "/channels/{channel.id}/messages/{message.id}/reactions/"+urlencode(emoji)+"/@me", std::to_string(channel_id), std::to_string(message_id));
+                auto route = get_route("PUT", "/channels/{channel.id}/messages/{message.id}/reactions/"+url_encode(emoji)+"/@me", std::to_string(channel_id), std::to_string(message_id));
                 return request(route, token);
             }
 
             pplx::task<void> rest_api_client::delete_own_reaction(uint64_t channel_id, uint64_t message_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = get_route("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/"+urlencode(emoji)+"/@me", std::to_string(channel_id), std::to_string(message_id));
+                auto route = get_route("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/"+url_encode(emoji)+"/@me", std::to_string(channel_id), std::to_string(message_id));
                 return request(route, token);
             }
 
             pplx::task<void> rest_api_client::delete_user_reaction(uint64_t channel_id, uint64_t message_id, uint64_t user_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = get_route("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/"+urlencode(emoji)+"/{user.id}", std::to_string(channel_id), std::to_string(message_id), std::to_string(user_id));
+                auto route = get_route("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/"+url_encode(emoji)+"/{user.id}", std::to_string(channel_id), std::to_string(message_id), std::to_string(user_id));
                 return request(route, token);
             }
 
             pplx::task<std::vector<disccord::models::user>> rest_api_client::get_reactions(uint64_t channel_id, uint64_t message_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = get_route("GET", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}", std::to_string(channel_id), std::to_string(message_id), urlencode(emoji));
+                auto route = get_route("GET", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}", std::to_string(channel_id), std::to_string(message_id), url_encode(emoji));
                 return request_multi_json<disccord::models::user>(route, token);
             }
 
@@ -628,7 +628,7 @@ namespace disccord
                 });
             }
             
-            std::string rest_api_client::urlencode(const std::string s)
+            std::string rest_api_client::url_encode(const std::string s)
             {
                 std::string lookup = "0123456789ABCDEF";
                 std::stringstream e;

--- a/lib/rest/api_client.cpp
+++ b/lib/rest/api_client.cpp
@@ -648,20 +648,6 @@ namespace disccord
                 return request_json<disccord::models::webhook>(route, args, token);
             }
 
-            pplx::task<disccord::models::webhook> rest_api_client::execute_slack_webhook(uint64_t webhook_id, std::string webhook_token, bool wait, const pplx::cancellation_token& token)
-            {
-                std::string wait_val = wait ? "true" : "false";
-                auto route = get_route("POST", "/webhooks/{webhook.id}/{webhook.token}/slack?wait={wait}", std::to_string(webhook_id), webhook_token, wait_val);
-                return request_json<disccord::models::webhook>(route, token);
-            }
-
-            pplx::task<disccord::models::webhook> rest_api_client::execute_github_webhook(uint64_t webhook_id, std::string webhook_token, bool wait, const pplx::cancellation_token& token)
-            {
-                std::string wait_val = wait ? "true" : "false";
-                auto route = get_route("POST", "/webhooks/{webhook.id}/{webhook.token}/github?wait={wait}", std::to_string(webhook_id), webhook_token, wait_val);
-                return request_json<disccord::models::webhook>(route, token);
-            }
-
             disccord::api::bucket_info* rest_api_client::get_bucket(route_info& info)
             {
                 auto bucket_itr = buckets.find(info.bucket_url);

--- a/lib/rest/api_client.cpp
+++ b/lib/rest/api_client.cpp
@@ -225,7 +225,7 @@ namespace disccord
 
             pplx::task<std::vector<disccord::models::message>> rest_api_client::get_channel_messages_before(uint64_t channel_id, uint64_t message_id, uint8_t limit, const pplx::cancellation_token& token)
             {
-                auto route = get_route("GET", "/channels/{channel.id}/messages?before={message}&limit=limit", std::to_string(channel_id), std::to_string(message_id));
+                auto route = get_route("GET", "/channels/{channel.id}/messages?before={message}&limit={limit}", std::to_string(channel_id), std::to_string(message_id), std::to_string(limit));
                 return request_multi_json<disccord::models::message>(route, token);
             }
 
@@ -267,13 +267,13 @@ namespace disccord
 
             pplx::task<void> rest_api_client::delete_user_reaction(uint64_t channel_id, uint64_t message_id, uint64_t user_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = get_route("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/"+urlencode(emoji)+"/{user_id}", std::to_string(channel_id), std::to_string(message_id), std::to_string(user_id));
+                auto route = get_route("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/"+urlencode(emoji)+"/{user.id}", std::to_string(channel_id), std::to_string(message_id), std::to_string(user_id));
                 return request(route, token);
             }
 
             pplx::task<std::vector<disccord::models::user>> rest_api_client::get_reactions(uint64_t channel_id, uint64_t message_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = get_route("GET", "/channels/{channel.id}/messages/{message.id}/reactions/"+urlencode(emoji), std::to_string(channel_id), std::to_string(message_id), emoji);
+                auto route = get_route("GET", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}", std::to_string(channel_id), std::to_string(message_id), urlencode(emoji));
                 return request_multi_json<disccord::models::user>(route, token);
             }
 
@@ -415,7 +415,7 @@ namespace disccord
 
             pplx::task<std::vector<disccord::models::guild_member>> rest_api_client::list_guild_members_before(uint64_t guild_id, uint64_t user_id, uint16_t limit, const pplx::cancellation_token& token)
             {
-                auto route = get_route("GET", "/guilds/{guild.id}/members?before={user}&limit={limit}", std::to_string(guild_id), std::to_string(user_id));
+                auto route = get_route("GET", "/guilds/{guild.id}/members?before={user}&limit={limit}", std::to_string(guild_id), std::to_string(user_id), std::to_string(limit));
                 return request_multi_json<disccord::models::guild_member>(route, token);
             }
 

--- a/lib/rest/models/create_webhook_args.cpp
+++ b/lib/rest/models/create_webhook_args.cpp
@@ -1,0 +1,48 @@
+#include <disccord/rest/models/create_webhook_args.hpp>
+
+namespace disccord
+{
+    namespace rest
+    {
+        namespace models
+        {
+            create_webhook_args::create_webhook_args(std::string _name)
+                : name(_name)
+            { }
+
+            create_webhook_args::~create_webhook_args()
+            { }
+
+            void create_webhook_args::encode_to(std::unordered_map<std::string, web::json::value>& info)
+            {
+                #define encode_field(var) \
+                    if (var.is_specified()) \
+                        info[#var] = web::json::value(var.get_value());
+
+                info["name"] = web::json::value(name);
+                encode_field(avatar);
+
+                #undef encode_field
+            }
+
+            #define define_set_method(field_name, type) \
+                void create_webhook_args::set_##field_name(type val) { \
+                    field_name = decltype(field_name)(val); \
+                }
+
+            define_set_method(name, std::string)
+            
+            void create_webhook_args::set_avatar(concurrency::streams::basic_istream<unsigned char> avatar_stream)
+            {
+                concurrency::streams::container_buffer<std::vector<unsigned char>> stream_buffer;
+                avatar_stream.read_to_end(stream_buffer).get();
+                auto stream_bytes = std::move(stream_buffer.collection());
+                stream_buffer.close();
+                std::string avatar_body = "data:image/jpeg;base64," + utility::conversions::to_base64(stream_bytes);
+                avatar = util::optional<std::string>(avatar_body);
+            }
+
+            #undef define_set_method
+        }
+    }
+}

--- a/lib/rest/models/execute_webhook_args.cpp
+++ b/lib/rest/models/execute_webhook_args.cpp
@@ -1,0 +1,56 @@
+#include <disccord/rest/models/execute_webhook_args.hpp>
+
+namespace disccord
+{
+    namespace rest
+    {
+        namespace models
+        {
+            execute_webhook_args::execute_webhook_args(std::string _content)
+                : content(util::optional<std::string>(_content))
+            { }
+
+            execute_webhook_args::execute_webhook_args(std::vector<disccord::models::embed> _embeds)
+                : embeds(util::optional<std::vector<disccord::models::embed>>(_embeds))
+            { }
+
+            execute_webhook_args::~execute_webhook_args()
+            { }
+
+            void execute_webhook_args::encode_to(std::unordered_map<std::string, web::json::value>& info)
+            {
+                #define encode_field(var) \
+                    if (var.is_specified()) \
+                        info[#var] = web::json::value(var.get_value());
+
+                encode_field(content);
+                encode_field(username);
+                encode_field(avatar_url);
+                encode_field(tts);
+                if (embeds.is_specified())
+                {
+                    auto _embeds = embeds.get_value();
+                    std::vector<web::json::value> embed_array(_embeds.size());
+                    std::transform(_embeds.begin(), _embeds.end(), embed_array.begin(), [](disccord::models::embed field)
+                        {
+                            return field.encode();
+                        });
+                    info["embeds"] = web::json::value::array(embed_array);
+                }
+
+                #undef encode_field
+            }
+
+            #define define_set_method(field_name, type) \
+                void execute_webhook_args::set_##field_name(type val) { \
+                    field_name = decltype(field_name)(val); \
+                }
+
+            define_set_method(username, std::string)
+            define_set_method(avatar_url, std::string)
+            define_set_method(tts, bool)
+
+            #undef define_set_method
+        }
+    }
+}

--- a/lib/rest/models/modify_webhook_args.cpp
+++ b/lib/rest/models/modify_webhook_args.cpp
@@ -1,0 +1,47 @@
+#include <disccord/rest/models/modify_webhook_args.hpp>
+
+namespace disccord
+{
+    namespace rest
+    {
+        namespace models
+        {
+            modify_webhook_args::modify_webhook_args()
+            { }
+
+            modify_webhook_args::~modify_webhook_args()
+            { }
+
+            void modify_webhook_args::encode_to(std::unordered_map<std::string, web::json::value>& info)
+            {
+                #define encode_field(var) \
+                    if (var.is_specified()) \
+                        info[#var] = web::json::value(var.get_value());
+
+                encode_field(name);
+                encode_field(avatar);
+
+                #undef encode_field
+            }
+
+            #define define_set_method(field_name, type) \
+                void modify_webhook_args::set_##field_name(type val) { \
+                    field_name = decltype(field_name)(val); \
+                }
+
+            define_set_method(name, std::string)
+            
+            void modify_webhook_args::set_avatar(concurrency::streams::basic_istream<unsigned char> avatar_stream)
+            {
+                concurrency::streams::container_buffer<std::vector<unsigned char>> stream_buffer;
+                avatar_stream.read_to_end(stream_buffer).get();
+                auto stream_bytes = std::move(stream_buffer.collection());
+                stream_buffer.close();
+                std::string avatar_body = "data:image/jpeg;base64," + utility::conversions::to_base64(stream_bytes);
+                avatar = util::optional<std::string>(avatar_body);
+            }
+
+            #undef define_set_method
+        }
+    }
+}

--- a/tests/models.cpp
+++ b/tests/models.cpp
@@ -756,7 +756,7 @@ TEST_CASE( "Relationship model correctly instantiated" ){
     REQUIRE_NOTHROW(test_relationship.decode(web::json::value::parse(json)));
 
     REQUIRE(test_relationship.get_id() == 64234381431771993);
-    REQUIRE(test_relationship.get_type().get_value() == 4);
+    REQUIRE(test_relationship.get_type().get_value() == relationship_type::OutgoingPending);
 }
 
 TEST_CASE( "Ban model correctly instantiated" ){

--- a/tests/models.cpp
+++ b/tests/models.cpp
@@ -16,6 +16,7 @@
 #include <disccord/models/application.hpp>
 #include <disccord/models/voice_region.hpp>
 #include <disccord/models/voice_state.hpp>
+#include <disccord/models/webhook.hpp>
 #include <disccord/util/optional.hpp>
 
 #include <iostream>
@@ -912,4 +913,35 @@ TEST_CASE( "Voice state model correctly instantiated" ){
     REQUIRE(test_vs.get_self_deaf() == false);
     REQUIRE(test_vs.get_self_mute() == true);
     REQUIRE(test_vs.get_suppress() == false);
+}
+
+TEST_CASE( "Webhook model correctly instantiated" ){
+    webhook test_wh;
+    if (test_wh.get_channel_id() != 0 && !test_wh.get_token().empty())
+    {
+        FAIL("Default constructor for Webhook model not correctly instantiated");
+    }
+    
+    std::string json = R"({
+    "name": "test webhook",
+    "channel_id": "199737254929760256",
+    "token": "3d89bb7572e0fb30d8128367b3b1b44fecd1726de135cbe28a41f8b2f777c372ba2939e72279b94526ff5d1bd4358d65cf11",
+    "avatar": null,
+    "guild_id": "199737254929760256",
+    "id": "223704706495545344",
+    "user": {
+        "username": "test",
+        "discriminator": "7479",
+        "id": "190320984123768832",
+        "avatar": "b004ec1740a63ca06ae2e14c5cee11f3"
+    }
+})";
+
+    REQUIRE_NOTHROW(test_wh.decode(web::json::value::parse(json)));
+    
+    REQUIRE(test_wh.get_channel_id() == 199737254929760256);
+    REQUIRE(test_wh.get_guild_id().get_value() == 199737254929760256);
+    REQUIRE(test_wh.get_id() == 223704706495545344);
+    REQUIRE(test_wh.get_token() == "3d89bb7572e0fb30d8128367b3b1b44fecd1726de135cbe28a41f8b2f777c372ba2939e72279b94526ff5d1bd4358d65cf11");
+    REQUIRE(test_wh.get_name().get_value() == "test webhook");
 }


### PR DESCRIPTION
Fixing a few bugs (mostly related to model decoding/json parsing) and proposing some thing to add

## Things to Add
- [x] `url_encode` method impl for `create_reaction`, allows users to just use codepoints
- this would make users  use the "U\XXXXXXXX" format (or the unicode emoji itself) to create a reaction. 

**NOTE:** this has been tested to work with the following cases:
1. "U\XXXXXXXX" - **codepoints**
2. "✅" - **unicode emoji itself**
3. "disccord_memes:1234567891012313" - **custom emojis**

this only does not work when user sends in the percent encoding themselves, which is desired  behaviour.

**Examples**
```cpp
// usage of method
 url_encode("\U00002705"); //output: %E2%9C%85 (White Heavy Check Mark)
 url_encode("✅");         //output: %E2%9C%85 (White Heavy Check Mark)
 url_encode("\U0001F914"); //output: %F0%9F%A4%94 (Thinking Face)
 url_encode("\U00002B50"); //output: %E2%AD%90 (White Medium Star)

//actual usage in disccord(tm), reacting w/ heavy check mark
create_message_args cm_args("this is msg!");
auto msg = client.create_message(1234567891011,cm_args).get();
client.create_reaction(msg.get_channel_id(),msg.get_id(),"\U00002705").wait();
// or use actual emoji
client.create_reaction(msg.get_channel_id(),msg.get_id(),"✅").wait();
```

- [x] Wrap Webhook API
- forgot to do this one, someone out there may want to use it /shrug

## Fixes
- [x] fix `models::user_guild` decoding
- it is possible for an `icon` to be null, so that field must be optional

- [x] fix `list_guild_members`
- guild_member decoding issue, `bot` is not always present

- [x] update/fix `relationship` model
- man who wrote this bad code (heh)