### PR TITLE
Support Audit Logs

### DIFF
--- a/include/disccord/models/audit_log_action_type.hpp
+++ b/include/disccord/models/audit_log_action_type.hpp
@@ -3,38 +3,38 @@
 
 namespace disccord
 {
-namespace models
-{
-enum class audit_log_action_type
-{
-    all = 0, //in json resp, discord represents all as null, will need to make a check
-    guild_update = 1,
-    channel_create = 10,
-    channel_update = 11,
-    channel_delete = 12,
-    channel_overwrite_create = 13,
-    channel_overwrite_update = 14,
-    channel_overwrite_delete = 15,
-    member_kick = 20,
-    member_prune = 21,
-    member_ban_add = 22,
-    member_ban_remove = 23,
-    member_update = 24,
-    member_role_update = 25,
-    role_create = 30,
-    role_update = 31,
-    role_delete = 32,
-    invite_create = 40,
-    invite_update = 41,
-    invite_delete = 42,
-    webhook_create = 50,
-    webhook_update = 51,
-    webhook_delete = 52,
-    emoji_create = 60,
-    emoji_update = 61,
-    emoji_delete = 62
-};
-} //namespace models
+    namespace models
+    {
+        enum class audit_log_action_type
+        {
+            all = 0, //in json resp, discord represents all as null, will need to make a check
+            guild_update = 1,
+            channel_create = 10,
+            channel_update = 11,
+            channel_delete = 12,
+            channel_overwrite_create = 13,
+            channel_overwrite_update = 14,
+            channel_overwrite_delete = 15,
+            member_kick = 20,
+            member_prune = 21,
+            member_ban_add = 22,
+            member_ban_remove = 23,
+            member_update = 24,
+            member_role_update = 25,
+            role_create = 30,
+            role_update = 31,
+            role_delete = 32,
+            invite_create = 40,
+            invite_update = 41,
+            invite_delete = 42,
+            webhook_create = 50,
+            webhook_update = 51,
+            webhook_delete = 52,
+            emoji_create = 60,
+            emoji_update = 61,
+            emoji_delete = 62
+        };
+    } //namespace models
 } //namesapce disccord
 
 #endif /* _audit_log_action_type_hpp_ */

--- a/include/disccord/models/audit_log_action_type.hpp
+++ b/include/disccord/models/audit_log_action_type.hpp
@@ -1,0 +1,40 @@
+#ifndef _audit_log_action_type_hpp_
+#define _audit_log_action_type_hpp_
+
+namespace disccord
+{
+namespace models
+{
+enum class audit_log_action_type
+{
+    all = 0, //in json resp, discord represents all as null, will need to make a check
+    guild_update = 1,
+    channel_create = 10,
+    channel_update = 11,
+    channel_delete = 12,
+    channel_overwrite_create = 13,
+    channel_overwrite_update = 14,
+    channel_overwrite_delete = 15,
+    member_kick = 20,
+    member_prune = 21,
+    member_ban_add = 22,
+    member_ban_remove = 23,
+    member_update = 24,
+    member_role_update = 25,
+    role_create = 30,
+    role_update = 31,
+    role_delete = 32,
+    invite_create = 40,
+    invite_update = 41,
+    invite_delete = 42,
+    webhook_create = 50,
+    webhook_update = 51,
+    webhook_delete = 52,
+    emoji_create = 60,
+    emoji_update = 61,
+    emoji_delete = 62
+};
+} //namespace models
+} //namesapce disccord
+
+#endif /* _audit_log_action_type_hpp_ */

--- a/include/disccord/models/audit_log_change.hpp
+++ b/include/disccord/models/audit_log_change.hpp
@@ -31,21 +31,23 @@ namespace disccord
         class audit_log_change : public model
         {
             public:
+                using change_value = boost::variant<uint64_t, std::string, bool, std::vector<roles_change>>;
+
                 audit_log_change();
                 virtual ~audit_log_change();
 
                 virtual void decode(web::json::value json) override;
 
                 std::string get_key();
-                util::optional<boost::variant<uint64_t, std::string, bool, std::vector<roles_change>>> get_new_value();
-                util::optional<boost::variant<uint64_t, std::string, bool, std::vector<roles_change>>> get_old_value();
+                util::optional<change_value> get_new_value();
+                util::optional<change_value> get_old_value();
 
             protected:
                 virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
 
             private:
                 std::string key;
-                util::optional<boost::variant<uint64_t, std::string, bool, std::vector<roles_change>>> new_value, old_value;
+                util::optional<change_value> new_value, old_value;
         };
     } // namespace models
 } // namespace disccord

--- a/include/disccord/models/audit_log_change.hpp
+++ b/include/disccord/models/audit_log_change.hpp
@@ -6,39 +6,39 @@
 
 namespace disccord
 {
-namespace models
-{
-class audit_log_change : public model
-{
-    public:
-        audit_log_change();
-        virtual ~audit_log_change();
-
-        virtual void decode(web::json::value json) override;
-
-        std::string get_key();
-        template <typename T>
-        T get_new_value()
+    namespace models
+    {
+        class audit_log_change : public model
         {
-            return new_value;
-        }
-        template <typename T>
-        util::optional<T> get_old_value()
-        {
-            return old_value;
-        }
+            public:
+                audit_log_change();
+                virtual ~audit_log_change();
 
-    protected:
-        virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
+                virtual void decode(web::json::value json) override;
 
-    private:
-        std::string key;
-        template <typename T>
-        T new_value;
-        template <typename T>
-        util::optional<T> old_value;
-};
-} // namespace models
+                std::string get_key();
+                template <typename T>
+                T get_new_value()
+                {
+                    return new_value;
+                }
+                template <typename T>
+                util::optional<T> get_old_value()
+                {
+                    return old_value;
+                }
+
+            protected:
+                virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
+
+            private:
+                std::string key;
+                template <typename T>
+                T new_value;
+                template <typename T>
+                util::optional<T> old_value;
+        };
+    } // namespace models
 } // namespace disccord
 
 #endif /* _audit_log_change_hpp_ */

--- a/include/disccord/models/audit_log_change.hpp
+++ b/include/disccord/models/audit_log_change.hpp
@@ -17,26 +17,15 @@ namespace disccord
                 virtual void decode(web::json::value json) override;
 
                 std::string get_key();
-                template <typename T>
-                T get_new_value()
-                {
-                    return new_value;
-                }
-                template <typename T>
-                util::optional<T> get_old_value()
-                {
-                    return old_value;
-                }
+                std::string get_new_value();
+                util::optional<std::string> get_old_value();
 
             protected:
                 virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
 
             private:
-                std::string key;
-                template <typename T>
-                T new_value;
-                template <typename T>
-                util::optional<T> old_value;
+                std::string key, new_value;
+                util::optional<std::string> old_value;
         };
     } // namespace models
 } // namespace disccord

--- a/include/disccord/models/audit_log_change.hpp
+++ b/include/disccord/models/audit_log_change.hpp
@@ -1,13 +1,33 @@
 #ifndef _audit_log_change_hpp_
 #define _audit_log_change_hpp_
 
-#include <disccord/models/model.hpp>
+#include <boost/variant.hpp>
+#include <boost/variant/get.hpp>
+
+#include <disccord/models/entity.hpp>
 #include <disccord/util/optional.hpp>
 
 namespace disccord
 {
     namespace models
     {
+        class roles_change: public entity // class wrapping role updates (from the change key $add or $remove)
+        {
+            public:
+                roles_change();
+                virtual ~roles_change();
+                
+                virtual void decode(web::json::value json) override;
+                
+                std::string get_name();
+                
+            protected:
+                virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
+                
+            private:
+                std::string name;
+        };
+        
         class audit_log_change : public model
         {
             public:
@@ -17,15 +37,15 @@ namespace disccord
                 virtual void decode(web::json::value json) override;
 
                 std::string get_key();
-                std::string get_new_value();
-                util::optional<std::string> get_old_value();
+                util::optional<boost::variant<uint64_t, std::string, bool, std::vector<roles_change>>> get_new_value();
+                util::optional<boost::variant<uint64_t, std::string, bool, std::vector<roles_change>>> get_old_value();
 
             protected:
                 virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
 
             private:
-                std::string key, new_value;
-                util::optional<std::string> old_value;
+                std::string key;
+                util::optional<boost::variant<uint64_t, std::string, bool, std::vector<roles_change>>> new_value, old_value;
         };
     } // namespace models
 } // namespace disccord

--- a/include/disccord/models/audit_log_change.hpp
+++ b/include/disccord/models/audit_log_change.hpp
@@ -1,0 +1,44 @@
+#ifndef _audit_log_change_hpp_
+#define _audit_log_change_hpp_
+
+#include <disccord/models/model.hpp>
+#include <disccord/util/optional.hpp>
+
+namespace disccord
+{
+namespace models
+{
+class audit_log_change : public model
+{
+    public:
+        audit_log_change();
+        virtual ~audit_log_change();
+
+        virtual void decode(web::json::value json) override;
+
+        std::string get_key();
+        template <typename T>
+        T get_new_value()
+        {
+            return new_value;
+        }
+        template <typename T>
+        util::optional<T> get_old_value()
+        {
+            return old_value;
+        }
+
+    protected:
+        virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
+
+    private:
+        std::string key;
+        template <typename T>
+        T new_value;
+        template <typename T>
+        util::optional<T> old_value;
+};
+} // namespace models
+} // namespace disccord
+
+#endif /* _audit_log_change_hpp_ */

--- a/include/disccord/models/audit_log_entry.hpp
+++ b/include/disccord/models/audit_log_entry.hpp
@@ -1,0 +1,37 @@
+#ifndef _audit_log_entry_hpp_
+#define _audit_log_entry_hpp_
+
+#include <disccord/models/entity.hpp>
+#include <disccord/models/audit_log_change.hpp>
+#include <disccord/models/audit_log_action_type.hpp>
+
+namespace disccord
+{
+namespace models
+{
+class audit_log_entry : public entity
+{
+    public:
+        audit_log_entry();
+        virtual ~audit_log_entry();
+
+        virtual void decode(web::json::value json) override;
+
+        util::optional<uint64_t> get_target_id();
+        uint64_t get_user_id();
+        audit_log_action_type get_action_type();
+        std::vector<audit_log_change> get_changes();
+
+    protected:
+        virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
+
+    private:
+        util::optional<uint64_t> target_id;
+        uint64_t user_id;
+        audit_log_action_type action_type;
+        std::vector<audit_log_change> changes;
+};
+} // namespace models
+} // namespace disccord
+
+#endif /* _audit_log_entry_hpp_ */

--- a/include/disccord/models/audit_log_entry.hpp
+++ b/include/disccord/models/audit_log_entry.hpp
@@ -19,7 +19,7 @@ namespace disccord
 
                 util::optional<uint64_t> get_target_id();
                 uint64_t get_user_id();
-                uint8_t get_action_type();
+                audit_log_action_type get_action_type();
                 util::optional<std::vector<audit_log_change>> get_changes();
 
             protected:
@@ -28,7 +28,7 @@ namespace disccord
             private:
                 util::optional<uint64_t> target_id;
                 uint64_t user_id;
-                uint8_t action_type;
+                audit_log_action_type action_type;
                 util::optional<std::vector<audit_log_change>> changes;
         };
     } // namespace models

--- a/include/disccord/models/audit_log_entry.hpp
+++ b/include/disccord/models/audit_log_entry.hpp
@@ -7,31 +7,31 @@
 
 namespace disccord
 {
-namespace models
-{
-class audit_log_entry : public entity
-{
-    public:
-        audit_log_entry();
-        virtual ~audit_log_entry();
+    namespace models
+    {
+        class audit_log_entry : public entity
+        {
+            public:
+                audit_log_entry();
+                virtual ~audit_log_entry();
 
-        virtual void decode(web::json::value json) override;
+                virtual void decode(web::json::value json) override;
 
-        util::optional<uint64_t> get_target_id();
-        uint64_t get_user_id();
-        audit_log_action_type get_action_type();
-        std::vector<audit_log_change> get_changes();
+                util::optional<uint64_t> get_target_id();
+                uint64_t get_user_id();
+                audit_log_action_type get_action_type();
+                std::vector<audit_log_change> get_changes();
 
-    protected:
-        virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
+            protected:
+                virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
 
-    private:
-        util::optional<uint64_t> target_id;
-        uint64_t user_id;
-        audit_log_action_type action_type;
-        std::vector<audit_log_change> changes;
-};
-} // namespace models
+            private:
+                util::optional<uint64_t> target_id;
+                uint64_t user_id;
+                audit_log_action_type action_type;
+                std::vector<audit_log_change> changes;
+        };
+    } // namespace models
 } // namespace disccord
 
 #endif /* _audit_log_entry_hpp_ */

--- a/include/disccord/models/audit_log_entry.hpp
+++ b/include/disccord/models/audit_log_entry.hpp
@@ -19,8 +19,8 @@ namespace disccord
 
                 util::optional<uint64_t> get_target_id();
                 uint64_t get_user_id();
-                audit_log_action_type get_action_type();
-                std::vector<audit_log_change> get_changes();
+                uint8_t get_action_type();
+                util::optional<std::vector<audit_log_change>> get_changes();
 
             protected:
                 virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
@@ -28,8 +28,8 @@ namespace disccord
             private:
                 util::optional<uint64_t> target_id;
                 uint64_t user_id;
-                audit_log_action_type action_type;
-                std::vector<audit_log_change> changes;
+                uint8_t action_type;
+                util::optional<std::vector<audit_log_change>> changes;
         };
     } // namespace models
 } // namespace disccord

--- a/include/disccord/models/audit_logs.hpp
+++ b/include/disccord/models/audit_logs.hpp
@@ -19,16 +19,16 @@ namespace disccord
                 virtual void decode(web::json::value json) override;
 
                 //std::vector<webhook> get_webhooks();
-                std::vector<user> get_users();
-                std::vector<audit_log_entry> get_entries();
+                util::optional<std::vector<user>> get_users();
+                util::optional<std::vector<audit_log_entry>> get_entries();
 
             protected:
                 virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
 
             private:
                 //std::vector<webhook> webhooks;
-                std::vector<user> users;
-                std::vector<audit_log_entry> entries;
+                util::optional<std::vector<user>> users;
+                util::optional<std::vector<audit_log_entry>> entries;
         };
     } // namespace models
 } // namespace disccord

--- a/include/disccord/models/audit_logs.hpp
+++ b/include/disccord/models/audit_logs.hpp
@@ -1,0 +1,33 @@
+#ifndef _audit_logs_hpp_
+#define _audit_logs_hpp_
+
+#include <disccord/models/model.hpp>
+#include <disccord/models/user.hpp>
+#include <disccord/models/audit_log_entry.hpp>
+
+namespace disccord
+{
+namespace models
+{
+class audit_logs : public entity
+{
+    public:
+        audit_logs();
+        virtual ~audit_logs();
+
+        virtual void decode(web::json::value json) override;
+
+        std::vector<user> get_users();
+        std::vector<audit_log_entry> get_entries();
+
+    protected:
+        virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
+
+    private:
+        std::vector<user> users;
+        std::vector<audit_log_entry> entries;
+};
+} // namespace models
+} // namespace disccord
+
+#endif /* _audit_logs_hpp_ */

--- a/include/disccord/models/audit_logs.hpp
+++ b/include/disccord/models/audit_logs.hpp
@@ -9,7 +9,7 @@ namespace disccord
 {
     namespace models
     {
-        class audit_logs : public entity
+        class audit_logs : public model
         {
             public:
                 audit_logs();

--- a/include/disccord/models/audit_logs.hpp
+++ b/include/disccord/models/audit_logs.hpp
@@ -3,6 +3,7 @@
 
 #include <disccord/models/model.hpp>
 #include <disccord/models/user.hpp>
+//#include <disccord/models/webhook.hpp>
 #include <disccord/models/audit_log_entry.hpp>
 
 namespace disccord
@@ -17,6 +18,7 @@ namespace disccord
 
                 virtual void decode(web::json::value json) override;
 
+                //std::vector<webhook> get_webhooks();
                 std::vector<user> get_users();
                 std::vector<audit_log_entry> get_entries();
 
@@ -24,6 +26,7 @@ namespace disccord
                 virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
 
             private:
+                //std::vector<webhook> webhooks;
                 std::vector<user> users;
                 std::vector<audit_log_entry> entries;
         };

--- a/include/disccord/models/audit_logs.hpp
+++ b/include/disccord/models/audit_logs.hpp
@@ -7,27 +7,27 @@
 
 namespace disccord
 {
-namespace models
-{
-class audit_logs : public entity
-{
-    public:
-        audit_logs();
-        virtual ~audit_logs();
+    namespace models
+    {
+        class audit_logs : public entity
+        {
+            public:
+                audit_logs();
+                virtual ~audit_logs();
 
-        virtual void decode(web::json::value json) override;
+                virtual void decode(web::json::value json) override;
 
-        std::vector<user> get_users();
-        std::vector<audit_log_entry> get_entries();
+                std::vector<user> get_users();
+                std::vector<audit_log_entry> get_entries();
 
-    protected:
-        virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
+            protected:
+                virtual void encode_to(std::unordered_map<std::string, web::json::value> &info) override;
 
-    private:
-        std::vector<user> users;
-        std::vector<audit_log_entry> entries;
-};
-} // namespace models
+            private:
+                std::vector<user> users;
+                std::vector<audit_log_entry> entries;
+        };
+    } // namespace models
 } // namespace disccord
 
 #endif /* _audit_logs_hpp_ */

--- a/include/disccord/rest/api_client.hpp
+++ b/include/disccord/rest/api_client.hpp
@@ -25,6 +25,8 @@
 #include <disccord/models/user.hpp>
 #include <disccord/models/user_guild.hpp>
 #include <disccord/models/voice_region.hpp>
+#include <disccord/models/audit_logs.hpp>
+#include <disccord/models/audit_log_action_type.hpp>
 
 #include <disccord/rest/models/guild_prune.hpp>
 #include <disccord/rest/models/nickname.hpp>
@@ -209,6 +211,12 @@ namespace disccord
                     pplx::task<disccord::models::guild_embed> get_guild_embed(uint64_t guild_id, const pplx::cancellation_token& token = pplx::cancellation_token::none());
 
                     pplx::task<disccord::models::guild_embed> modify_guild_embed(uint64_t guild_id, disccord::rest::models::modify_guild_embed_args args, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<disccord::models::audit_logs> get_audit_logs(uint64_t guild_id, disccord::models::audit_log_action_type action_type = disccord::models::audit_log_action_type::all, uint8_t limit = 100, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<disccord::models::audit_logs> get_audit_logs_before(uint64_t guild_id, uint64_t user_id, disccord::models::audit_log_action_type action_type = disccord::models::audit_log_action_type::all, uint8_t limit = 100, const pplx::cancellation_token& token = pplx::cancellation_token::none());
+
+                    pplx::task<disccord::models::audit_logs> get_audit_logs_after(uint64_t guild_id, uint64_t user_id, disccord::models::audit_log_action_type action_type = disccord::models::audit_log_action_type::all, uint8_t limit = 100, const pplx::cancellation_token& token = pplx::cancellation_token::none());
 
                     // Voice API
                     pplx::task<std::vector<disccord::models::voice_region>> list_voice_regions(const pplx::cancellation_token& token = pplx::cancellation_token::none());

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,7 @@ models/integration_account.cpp models/integration.cpp models/channel.cpp
 models/overwrite.cpp models/connection.cpp models/game.cpp models/presence.cpp
 models/guild_embed.cpp models/guild_member.cpp models/read_state.cpp models/relationship.cpp
 models/ban.cpp models/application.cpp models/voice_region.cpp models/voice_state.cpp
+models/audit_logs.cpp models/audit_log_entry.cpp models/audit_log_change.cpp
 rest/models/nickname.cpp rest/models/guild_prune.cpp rest/models/create_dm_channel_args.cpp
 rest/models/create_group_dm_args.cpp rest/models/create_message_args.cpp
 rest/models/create_guild_ban_args.cpp rest/models/modify_current_nick_args.cpp

--- a/lib/models/audit_log_change.cpp
+++ b/lib/models/audit_log_change.cpp
@@ -4,8 +4,36 @@ namespace disccord
 {
     namespace models
     {
+        // roles_change
+        roles_change::roles_change()
+            : name("")
+        { }
+        
+        roles_change::~roles_change()
+        { }
+        
+        void roles_change::decode(web::json::value json)
+        {
+            entity::decode(json);
+            
+            name = json.at("name").as_string();
+        }
+        
+        void roles_change::encode_to(std::unordered_map<std::string, web::json::value> &info)
+        {
+            entity::encode_to(info);
+            
+            info["name"] = web::json::value(name);
+        }
+        
+        std::string roles_change::get_name()
+        {
+            return name;
+        }
+        
+        // audit_log_change
         audit_log_change::audit_log_change()
-            : key("")
+            : key(""), new_value(), old_value()
         { }
 
         audit_log_change::~audit_log_change()
@@ -14,11 +42,93 @@ namespace disccord
         void audit_log_change::decode(web::json::value json)
         {
             key = json.at("key").as_string();
+
+            #define get_field(var) \
+                if (json.has_field(#var)) { \
+                    auto field = json.at(#var); \
+                    if (!field.is_null() && !field.is_array() && !field.is_object()) { \
+                        if (json.at(#var).is_number()) \
+                            var = decltype(var)(std::to_string(json.at(#var).as_integer())); \
+                        else if (json.at(#var).is_boolean()) \
+                            var = decltype(var)(json.at(#var).as_bool()); \
+                        else \
+                            var = decltype(var)(json.at(#var).as_string()); \
+                    } else { \
+                        var = decltype(var)::no_value(); \
+                    } \
+                } else { \
+                    var = decltype(var)(); \
+                }
+
+            #define get_composite_field_vector(var, type) \
+                if (json.has_field(#var)) { \
+                    auto _fields_array = json.at(#var).as_array(); \
+                    std::vector<type> fields_array(_fields_array.size()); \
+                    std::transform(_fields_array.begin(), _fields_array.end(), fields_array.begin(), \
+                    [](web::json::value _field){ \
+                        type field; \
+                        field.decode(_field); \
+                        return field; \
+                    }); \
+                    var = decltype(var)(fields_array); \
+                } else { \
+                    var = decltype(var)(); \
+                }
+            
+            if (key == "$add" || key == "$remove")
+            {
+                get_composite_field_vector(new_value, roles_change);
+                get_composite_field_vector(old_value, roles_change);
+            }
+            else
+            {
+                get_field(new_value);
+                get_field(old_value);
+            }
+
+            #undef get_field
+            #undef get_composite_field_vector
         }
 
         void audit_log_change::encode_to(std::unordered_map<std::string, web::json::value> &info)
         {
             info["key"] = web::json::value(key);
+            
+            #define encode_field(var) \
+                if (var.is_specified()) { \
+                    auto val = get_##var().get_value(); \
+                    if (val.which() == 0) \
+                        info[#var] = web::json::value(boost::get<uint64_t>(val)); \
+                    else if (val.which() == 1) \
+                        info[#var] = web::json::value(boost::get<std::string>(val)); \
+                    else if (val.which() == 2) \
+                        info[#var] = web::json::value(boost::get<bool>(val)); \
+                } 
+            
+            #define encode_composite_vector(var, type) \
+                if (var.is_specified()) { \
+                    auto val = get_##var().get_value(); \
+                    auto _array = boost::get<type>(val); \
+                    std::vector<web::json::value> array(_array.size()); \
+                    std::transform(_array.begin(), _array.end(), array.begin(), \
+                    [](roles_change _field){ \
+                        return _field.encode(); \
+                    }); \
+                    info[#var] = web::json::value::array(array); \
+                }
+            if (key == "$add" || key == "$remove")
+            {
+                encode_composite_vector(old_value, std::vector<roles_change>);
+                encode_composite_vector(new_value, std::vector<roles_change>);
+            }
+            else
+            {
+                encode_field(new_value);
+                encode_field(old_value);
+            }
+            
+            #undef encode_field
+            #undef encode_composite_vector
         }
 
         #define define_get_method(field_name) \
@@ -27,6 +137,8 @@ namespace disccord
             }
 
         define_get_method(key)
+        define_get_method(new_value)
+        define_get_method(old_value)
 
         #undef define_get_method
     }

--- a/lib/models/audit_log_change.cpp
+++ b/lib/models/audit_log_change.cpp
@@ -1,0 +1,33 @@
+#include <disccord/models/audit_log_change.hpp>
+
+namespace disccord
+{
+    namespace models
+    {
+        audit_log_change::audit_log_change()
+            : key("")
+        { }
+
+        audit_log_change::~audit_log_change()
+        { }
+
+        void audit_log_change::decode(web::json::value json)
+        {
+            key = json.at("key").as_string();
+        }
+
+        void audit_log_change::encode_to(std::unordered_map<std::string, web::json::value> &info)
+        {
+            info["key"] = web::json::value(key);
+        }
+
+        #define define_get_method(field_name) \
+            decltype(audit_log_change::field_name) audit_log_change::get_##field_name() { \
+                return field_name; \
+            }
+
+        define_get_method(key)
+
+        #undef define_get_method
+    }
+}

--- a/lib/models/audit_log_entry.cpp
+++ b/lib/models/audit_log_entry.cpp
@@ -7,7 +7,7 @@ namespace disccord
     namespace models
     {
         audit_log_entry::audit_log_entry()
-            : target_id(), user_id(0), action_type(0), changes()
+            : target_id(), user_id(0), action_type(audit_log_action_type::all), changes()
         { }
 
         audit_log_entry::~audit_log_entry()
@@ -16,7 +16,7 @@ namespace disccord
         void audit_log_entry::decode(web::json::value json)
         {
             user_id = std::stoull(json.at("user_id").as_string());
-            action_type = json.at("action_type").as_integer();
+            action_type = audit_log_action_type(json.at("action_type").as_integer());
 
             #define get_id_field(var) \
                 if (json.has_field(#var)) { \
@@ -51,7 +51,7 @@ namespace disccord
         void audit_log_entry::encode_to(std::unordered_map<std::string, web::json::value> &info)
         {
             info["user_id"] = web::json::value(std::to_string(user_id));
-            info["action_type"] = web::json::value(action_type);
+            info["action_type"] = web::json::value((uint8_t)action_type);
             if (target_id.is_specified())
                 info["target_id"] = get_target_id();
             if (changes.is_specified())

--- a/lib/models/audit_log_entry.cpp
+++ b/lib/models/audit_log_entry.cpp
@@ -1,0 +1,81 @@
+#include <vector>
+
+#include <disccord/models/audit_log_entry.hpp>
+
+namespace disccord
+{
+    namespace models
+    {
+        audit_log_entry::audit_log_entry()
+            : target_id(), user_id(0), action_type(0), changes()
+        { }
+
+        audit_log_entry::~audit_log_entry()
+        { }
+
+        void audit_log_entry::decode(web::json::value json)
+        {
+            user_id = std::stoull(json.at("user_id").as_string());
+            action_type = json.at("action_type").as_integer();
+
+            #define get_id_field(var) \
+                if (json.has_field(#var)) { \
+                    auto field = json.at(#var); \
+                    if (!field.is_null()) { \
+                        var = decltype(var)(std::stoull(field.as_string())); \
+                    } else { \
+                        var = decltype(var)::no_value(); \
+                    } \
+                } else { \
+                    var = decltype(var)(); \
+                }
+
+            get_id_field(target_id);
+
+            if (json.has_field("changes"))
+            {
+                auto _changes_array = json.at("changes").as_array();
+                std::vector<audit_log_change> changes_array(_changes_array.size());
+                std::transform(_changes_array.begin(), _changes_array.end(), changes_array.begin(), [](web::json::value _change)
+                    {
+                        audit_log_change change;
+                        change.decode(_change);
+                        return change;
+                    });
+                changes = changes_array;
+            }
+
+            #undef get_id_field
+        }
+
+        void audit_log_entry::encode_to(std::unordered_map<std::string, web::json::value> &info)
+        {
+            info["user_id"] = web::json::value(std::to_string(user_id));
+            info["action_type"] = web::json::value(action_type);
+            if (target_id.is_specified())
+                info["target_id"] = get_target_id();
+            if (changes.is_specified())
+            {
+                auto _changes = get_changes().get_value();
+                std::vector<web::json::value> change_array(_changes.size());
+                std::transform(_changes.begin(), _changes.end(), change_array.begin(), [](audit_log_change change)
+                    {
+                        return change.encode();
+                    });
+                info["changes"] = web::json::value::array(change_array);
+            }
+        }
+
+        #define define_get_method(field_name) \
+            decltype(audit_log_entry::field_name) audit_log_entry::get_##field_name() { \
+                return field_name; \
+            }
+
+        define_get_method(target_id)
+        define_get_method(user_id)
+        define_get_method(action_type)
+        define_get_method(changes)
+
+        #undef define_get_method
+    }
+}

--- a/lib/models/audit_logs.cpp
+++ b/lib/models/audit_logs.cpp
@@ -1,0 +1,78 @@
+#include <vector>
+
+#include <disccord/models/audit_logs.hpp>
+
+namespace disccord
+{
+    namespace models
+    {
+        audit_logs::audit_logs()
+            : users(), entries()
+        { }
+
+        audit_logs::~audit_logs()
+        { }
+
+        void audit_logs::decode(web::json::value json)
+        {
+            /* if (json.has_field("users"))
+            {
+                auto _users_array = json.at("users").as_array();
+                std::vector<user> users_array(_users_array.size());
+                std::transform(_users_array.begin(), _users_array.end(), users_array.begin(), [](web::json::value _user)
+                    {
+                        models::user user;
+                        user.decode(_user);
+                        return user;
+                    });
+                users = users_array;
+            } */
+            if (json.has_field("audit_log_entries"))
+            {
+                auto _entries_array = json.at("audit_log_entries").as_array();
+                std::vector<audit_log_entry> entries_array(_entries_array.size());
+                std::transform(_entries_array.begin(), _entries_array.end(), entries_array.begin(), [](web::json::value _entry)
+                    {
+                        audit_log_entry entry;
+                        entry.decode(_entry);
+                        return entry;
+                    });
+                entries = entries_array;
+            }
+        }
+
+        void audit_logs::encode_to(std::unordered_map<std::string, web::json::value> &info)
+        {
+            if (users.is_specified())
+            {
+                auto _users = get_users().get_value();
+                std::vector<web::json::value> users_array(_users.size());
+                std::transform(_users.begin(), _users.end(), users_array.begin(), [](models::user user)
+                    {
+                        return user.encode();
+                    });
+                info["users"] = web::json::value::array(users_array);
+            }
+            if (entries.is_specified())
+            {
+                auto _entries = get_entries().get_value();
+                std::vector<web::json::value> entries_array(_entries.size());
+                std::transform(_entries.begin(), _entries.end(), entries_array.begin(), [](audit_log_entry entry)
+                    {
+                        return entry.encode();
+                    });
+                info["entries"] = web::json::value::array(entries_array);
+            }
+        }
+
+        #define define_get_method(field_name) \
+            decltype(audit_logs::field_name) audit_logs::get_##field_name() { \
+                return field_name; \
+            }
+
+        define_get_method(users)
+        define_get_method(entries)
+
+        #undef define_get_method
+    }
+}

--- a/lib/rest/api_client.cpp
+++ b/lib/rest/api_client.cpp
@@ -579,6 +579,42 @@ namespace disccord
                 return request_json<disccord::models::guild_embed>(route, args, token);
             }
 
+            pplx::task<disccord::models::audit_logs> rest_api_client::get_audit_logs(uint64_t guild_id, disccord::models::audit_log_action_type action_type, uint8_t limit, const pplx::cancellation_token& token)
+            {
+                if (action_type == disccord::models::audit_log_action_type::all){
+                    auto route = get_route("GET", "/guilds/{guild.id}/audit-logs?limit={limit}", std::to_string(guild_id), std::to_string(limit));
+                    return request_json<disccord::models::audit_logs>(route, token);
+                }
+                else {
+                    auto route = get_route("GET", "/guilds/{guild.id}/audit-logs?limit={limit}&action_type={type}", std::to_string(guild_id), std::to_string(limit), std::to_string((uint8_t)action_type));
+                    return request_json<disccord::models::audit_logs>(route, token);
+                }
+            }
+
+            pplx::task<disccord::models::audit_logs> rest_api_client::get_audit_logs_before(uint64_t guild_id, uint64_t user_id, disccord::models::audit_log_action_type action_type, uint8_t limit, const pplx::cancellation_token& token)
+            {
+                if (action_type == disccord::models::audit_log_action_type::all){
+                    auto route = get_route("GET", "/guilds/{guild.id}/audit-logs?limit={limit}&before={user.id}", std::to_string(guild_id), std::to_string(limit), std::to_string(user_id));
+                    return request_json<disccord::models::audit_logs>(route, token);
+                }
+                else {
+                    auto route = get_route("GET", "/guilds/{guild.id}/audit-logs?limit={limit}&before={user.id}&action_type={type}", std::to_string(guild_id), std::to_string(limit), std::to_string((uint8_t)action_type));
+                    return request_json<disccord::models::audit_logs>(route, token);
+                }
+            }
+
+            pplx::task<disccord::models::audit_logs> rest_api_client::get_audit_logs_after(uint64_t guild_id, uint64_t user_id, disccord::models::audit_log_action_type action_type, uint8_t limit, const pplx::cancellation_token& token)
+            {
+                if (action_type == disccord::models::audit_log_action_type::all){
+                    auto route = get_route("GET", "/guilds/{guild.id}/audit-logs?limit={limit}&after={user.id}", std::to_string(guild_id), std::to_string(limit), std::to_string(user_id));
+                    return request_json<disccord::models::audit_logs>(route, token);
+                }
+                else {
+                    auto route = get_route("GET", "/guilds/{guild.id}/audit-logs?limit={limit}&after={user.id}&action_type={type}", std::to_string(guild_id), std::to_string(limit), std::to_string((uint8_t)action_type));
+                    return request_json<disccord::models::audit_logs>(route, token);
+                }
+            }
+
             // Voice API
             pplx::task<std::vector<disccord::models::voice_region>> rest_api_client::list_voice_regions(const pplx::cancellation_token& token)
             {


### PR DESCRIPTION
This PR will satisfy #32.

- [x] Configure a nice interface for the `audit_logs` model
- this also entails setting up enums for action types

- [x] Implement the model
- **NOTE:** need to wait for user decoding issue and webhook model to be merged in from #31 to get access to all the fields

- [x] Wrap the API endpoint

- [ ] Support audit log reasons via header `X-Audit-Log-Reason` or query param `?reason=` on audit-able endpoints

- [ ] Add unit tests for the model

**Examples**
```cpp
uint64_t guild = 12345678910111213; // some guild ID
client.get_audit_logs(guild).then([&](audit_logs logs)
{
    // action type defaults to audit_log_action_type::all in this case, so
    // we have the last 100 entries regardless of action type
    for (auto entry: logs.get_entries().get_value())
    {
       // get user info for each entry
        auto user = client.get_user(entry.get_user_id()).get();
        
        // send to log file, or build embed, or other stuff, etc etc
        // in this case, do stuff if the user had their role updated
        if (entry.get_action_type() == audit_log_action_type::member_role_update)
        {
            // stuff
        }
    }
}).wait();

// instead of having a check for specific action types, can just query the type you want instead
client.get_audit_logs(guild, audit_log_action_type::member_role_update).then([&](audit_logs logs)
{
    for (auto entry: logs.get_entries().get_value())
    {
       // get user info for each entry
        auto user = client.get_user(entry.get_user_id()).get();
        
        // all entries are from a member role update, do stuff here

        // the new_value and old_value can take on many types, so we implement with boost::variant. 
        // this example, with member_role_update, the data returned needs to be a custom data type, 
        // this is how you accessed the update roles data
        for (auto change: entry.get_changes().get_value()){
            auto role_updates = boost::get<std::vector<roles_change>>(change.get_new_value().get_value());
            auto role = role_updates[0];
            std::cout << "Role updated was: " << role.get_name() << "(" << role.get_id() << ")\n";
         }
    }
}).wait();
```