### PR TITLE
[REST] URL Encoder

### DIFF
--- a/include/disccord/util/url_encode.hpp
+++ b/include/disccord/util/url_encode.hpp
@@ -1,0 +1,14 @@
+#ifndef _url_encode_hpp_
+#define _url_encode_hpp_
+
+#include <string>
+
+namespace disccord
+{
+    namespace util
+    {
+        std::string url_encode(const std::string& s);
+    } // namespace util
+} // namespace disccord
+
+#endif /* _url_encode_hpp_ */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -11,8 +11,8 @@ set(LIBS ${LIBS} ${CPPREST_LIBRARIES} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES}
 
 set(SOURCE_FILES rest/api_client.cpp api/bucket_info.cpp
 api/multipart_field.cpp api/multipart_request.cpp api/multipart_file.cpp
-api/request_info.cpp rest/client.cpp util/semaphore.cpp ws/api_client.cpp
-ws/client.cpp)
+api/request_info.cpp rest/client.cpp util/semaphore.cpp util/url_encode.cpp
+ws/api_client.cpp ws/client.cpp)
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 

--- a/lib/rest/api_client.cpp
+++ b/lib/rest/api_client.cpp
@@ -3,6 +3,8 @@
 #include <disccord/rest/api_client.hpp>
 #include <disccord/rest.hpp>
 
+#include <disccord/util/url_encode.hpp>
+
 #include <disccord/rest/models/add_guild_member_args.hpp>
 #include <disccord/rest/models/create_dm_channel_args.hpp>
 #include <disccord/rest/models/create_group_dm_args.hpp>
@@ -267,25 +269,25 @@ namespace disccord
 
             pplx::task<void> rest_api_client::create_reaction(uint64_t channel_id, uint64_t message_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = build_route<3>("PUT", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me", {std::to_string(channel_id), std::to_string(message_id), emoji});
+                auto route = build_route<3>("PUT", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me", {std::to_string(channel_id), std::to_string(message_id), util::url_encode(emoji)});
                 return request(route, token);
             }
 
             pplx::task<void> rest_api_client::delete_own_reaction(uint64_t channel_id, uint64_t message_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = build_route<3>("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me", {std::to_string(channel_id), emoji, std::to_string(message_id)});
+                auto route = build_route<3>("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/@me", {std::to_string(channel_id), util::url_encode(emoji), std::to_string(message_id)});
                 return request(route, token);
             }
 
             pplx::task<void> rest_api_client::delete_user_reaction(uint64_t channel_id, uint64_t message_id, uint64_t user_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = build_route<4>("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/{user.id}", {std::to_string(channel_id), std::to_string(message_id), emoji, std::to_string(user_id)});
+                auto route = build_route<4>("DELETE", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}/{user.id}", {std::to_string(channel_id), std::to_string(message_id), util::url_encode(emoji), std::to_string(user_id)});
                 return request(route, token);
             }
 
             pplx::task<std::vector<disccord::models::user>> rest_api_client::get_reactions(uint64_t channel_id, uint64_t message_id, std::string emoji, const pplx::cancellation_token& token)
             {
-                auto route = build_route<3>("GET", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}", {std::to_string(channel_id), std::to_string(message_id), emoji});
+                auto route = build_route<3>("GET", "/channels/{channel.id}/messages/{message.id}/reactions/{emoji}", {std::to_string(channel_id), std::to_string(message_id), util::url_encode(emoji)});
                 return request_multi_json<disccord::models::user>(route, token);
             }
 

--- a/lib/util/url_encode.cpp
+++ b/lib/util/url_encode.cpp
@@ -1,0 +1,35 @@
+#include <disccord/util/url_encode.hpp>
+
+#include <sstream>
+
+namespace disccord
+{
+    namespace util
+    {
+        std::string url_encode(const std::string& s)
+        {
+            std::string lookup = "0123456789ABCDEF";
+            std::stringstream e;
+             
+            for (const char &c : s) // RFC 3986 section 2.3 Unreserved Characters
+            {
+                if (('0' <= c && c <= '9') ||
+                    ('a' <= c && c <= 'z') ||
+                    ('A' <= c && c <= 'Z') ||
+                    (c=='-' || c=='_' || c=='.' || c=='~') 
+                )
+                {
+                    e << c;
+                }
+                else
+                {
+                    e << '%';
+                    e << lookup[(c & 0xF0) >> 4];
+                    e << lookup[(c & 0x0F)];
+                }
+            }
+            
+            return e.str();
+        }
+    } // namespace util
+} // namespace disccord


### PR DESCRIPTION
This is adding a `util::url_encode` method for all reaction-related endpoints. 
Now users can just use codepoints, "U\XXXXXXXX",  or the unicode emoji itself to use these endpoints.
Also, a few routes needed a touch up.

**NOTE:** this has been tested to work with the following cases:
1. "U\XXXXXXXX" - **codepoints**
2. "✅" - **unicode emoji itself**
3. "disccord_memes:1234567891012313" - **custom emojis**

Only does not work when user sends in the percent encoding themselves, (e.g. "%EA%B4%FF"). But this is a desired abstraction.

### Example Usage in the Library (Encoding the URL)
```cpp
// these methods are used when generating the reaction-related routes.
util::url_encode("\U00002705"); //output: %E2%9C%85 (White Heavy Check Mark)
util::url_encode("✅");         //output: %E2%9C%85 (White Heavy Check Mark)
util::url_encode("\U0001F914"); //output: %F0%9F%A4%94 (Thinking Face)
util::url_encode("\U00002B50"); //output: %E2%AD%90 (White Medium Star)
```

### Example Usage for a User (Message Reacting)
```cpp
// sending a message then auto reacting w/ heavy check mark

uint64_t c_id = 1234567891011;
create_message_args cm_args("wow disccord is such an amazing lib!");
auto msg = client.create_message(c_id, cm_args).get();

// using codepoints
client.create_reaction(msg.get_channel_id(), msg.get_id(), "\U00002705").wait();

// or using actual emoji
client.create_reaction(msg.get_channel_id(), msg.get_id(), "✅").wait();
```