### PR TITLE
[Websocket] Event Listener/Dispatcher and Event Enums

### DIFF
--- a/include/disccord/ws/client.hpp
+++ b/include/disccord/ws/client.hpp
@@ -5,9 +5,12 @@
 
 #include <cpprest/ws_client.h>
 
+#include <disccord/ws/event.hpp>
+
 #include <disccord/types.hpp>
 #include <disccord/rest/api_client.hpp>
 #include <disccord/ws/api_client.hpp>
+#include <disccord/ws/dispatcher.hpp>
 
 namespace disccord
 {
@@ -21,10 +24,20 @@ namespace disccord
                 virtual ~discord_ws_client();
 
                 pplx::task<void> connect(const pplx::cancellation_token& token = pplx::cancellation_token::none());
+                
+                void event(ws::event ev, std::function<void ()> func);
+
+                template<typename LambdaType>
+                void event(ws::event ev, LambdaType lambda)
+                {
+                    dispatcher.on(static_cast<unsigned int>(ev), lambda);
+                }
 
             private:
                 disccord::rest::internal::rest_api_client rest_api_client;
                 disccord::ws::internal::ws_api_client ws_api_client;
+                
+                disccord::ws::internal::dispatcher dispatcher;
 
                 pplx::cancellation_token_source heartbeat_cancel_token;
                 pplx::task<void> heartbeat_task;

--- a/include/disccord/ws/dispatcher.hpp
+++ b/include/disccord/ws/dispatcher.hpp
@@ -1,0 +1,169 @@
+// Copyright (c) 2014 Sean Farrell
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy 
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights 
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+// copies of the Software, and to permit persons to whom the Software is 
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+// SOFTWARE.
+//
+
+// MODIFIED BY: sedruk
+
+#ifndef _ws_dispatcher_hpp_
+#define _ws_dispatcher_hpp_
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <list>
+#include <algorithm>
+#include <string>
+
+#include <disccord/ws/event.hpp>
+
+namespace disccord
+{
+    namespace ws
+    {
+        namespace internal
+        {
+            class dispatcher
+            {
+            public:
+                
+                dispatcher();
+
+                virtual ~dispatcher();
+
+                unsigned int add_listener(unsigned int event_id, std::function<void ()> cb);
+                
+                template <typename... Args>
+                unsigned int add_listener(unsigned int event_id, std::function<void (Args...)> cb)
+                {
+                    if (!cb)
+                    {
+                        throw std::invalid_argument("dispatcher::add_listener: No callbak provided.");
+                    }
+
+                    std::lock_guard<std::mutex> lock(mutex);
+
+                    unsigned int listener_id = ++last_listener;
+                    listeners.insert(std::make_pair(event_id, std::make_shared<listener<Args...>>(listener_id, cb)));
+
+                    return listener_id;        
+                }
+
+                template<typename LambdaType>
+                unsigned int add_listener(unsigned int event_id, LambdaType lambda) {
+                    return add_listener(event_id, make_function(lambda));
+                }
+
+                unsigned int on(unsigned int event_id, std::function<void ()> cb);
+
+                template <typename... Args>
+                unsigned int on(unsigned int event_id, std::function<void (Args...)> cb)
+                {
+                    return add_listener(event_id, cb);
+                }
+
+                template<typename LambdaType>
+                unsigned int on(unsigned int event_id, LambdaType lambda) {
+                    return on(event_id, make_function(lambda));
+                }
+
+                void remove_listener(unsigned int listener_id);
+
+                template <typename... Args>
+                void emit(disccord::ws::event event_id, Args... args)
+                {
+                    std::list<std::shared_ptr<listener<Args...>>> handlers;
+
+                    {
+                        std::lock_guard<std::mutex> lock(mutex);
+
+                        auto range = listeners.equal_range(static_cast<unsigned int>(event_id));
+                        handlers.resize(std::distance(range.first, range.second));
+                        std::transform(range.first, range.second, handlers.begin(), [] (std::pair<const unsigned int, std::shared_ptr<listenerbase>> p) {
+                            auto l = std::dynamic_pointer_cast<listener<Args...>>(p.second);
+                            if (l)
+                            {
+                                return l;
+                            }
+                            else
+                            {
+                                throw std::logic_error("dispatcher::emit: Invalid event signature.");
+                            }
+                        });
+                    }
+
+                    for (auto& h : handlers)
+                    {
+                        h->cb(args...);
+                    }        
+                }
+
+                // http://stackoverflow.com/a/21000981
+                template <typename T>
+                struct function_traits
+                   : public function_traits<decltype(&T::operator())>
+                {};
+
+                template <typename ClassType, typename ReturnType, typename... Args>
+                struct function_traits<ReturnType(ClassType::*)(Args...) const> {
+                   typedef std::function<ReturnType (Args...)> f_type;
+                };
+
+                template <typename L> 
+                typename function_traits<L>::f_type make_function(L l){
+                  return (typename function_traits<L>::f_type)(l);
+                }
+
+            private:
+                struct listenerbase
+                {
+                    listenerbase() {}
+
+                    listenerbase(unsigned int i)
+                    : id(i) {}
+
+                    virtual ~listenerbase() {}
+
+                    unsigned int id;
+                };
+
+                template <typename... Args>
+                struct listener : public listenerbase
+                {
+                    listener() {}
+
+                    listener(unsigned int i, std::function<void (Args...)> c)
+                    : listenerbase(i), cb(c) {}
+
+                    std::function<void (Args...)> cb;
+                };
+
+                std::mutex mutex;
+                unsigned int last_listener;
+                std::multimap<unsigned int, std::shared_ptr<listenerbase>> listeners;
+
+                dispatcher(const dispatcher&) = delete;  
+                const dispatcher& operator = (const dispatcher&) = delete;
+            };
+        } //namespace internal
+    } // namespace ws
+} // namespace disccord
+
+#endif /* _ws_dispatcher_hpp_ */

--- a/include/disccord/ws/event.hpp
+++ b/include/disccord/ws/event.hpp
@@ -1,0 +1,44 @@
+#ifndef _event_hpp_
+#define _event_hpp_
+
+namespace disccord
+{
+    namespace ws
+    {
+        enum class event
+        {
+            UNKNOWN, //0
+            READY,
+            RESUMED,
+            CHANNEL_CREATE,
+            CHANNEL_UPDATE,
+            CHANNEL_DELETE,
+            GUILD_CREATE,
+            GUILD_UPDATE,
+            GUILD_DELETE,
+            GUILD_BAN_ADD,
+            GUILD_BAN_REMOVE, //10
+            GUILD_EMOJIS_UPDATE,
+            GUILD_INTEGRATIONS_UPDATE,
+            GUILD_MEMBER_ADD,
+            GUILD_MEMBER_REMOVE,
+            GUILD_MEMBER_UPDATE,
+            GUILD_MEMBERS_CHUNK,
+            GUILD_ROLE_CREATE,
+            GUILD_ROLE_UPDATE,
+            GUILD_ROLE_DELETE,
+            MESSAGE_CREATE, //20
+            MESSAGE_UPDATE,
+            MESSAGE_DELETE,
+            MESSAGE_DELETE_BULK,
+            PRESCENCE_UPDATE,
+            TYPING_START,
+            USER_SETTINGSUPDATE,
+            USER_UPDATE,
+            VOICE_STATE_UPDATE,
+            VOICE_SERVER_UPDATE //29
+        };
+    }
+}
+
+#endif /* _event_hpp_ */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,7 +12,7 @@ set(LIBS ${LIBS} ${CPPREST_LIBRARIES} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES}
 set(SOURCE_FILES rest/api_client.cpp api/bucket_info.cpp
 api/multipart_field.cpp api/multipart_request.cpp api/multipart_file.cpp
 api/request_info.cpp rest/client.cpp util/semaphore.cpp util/url_encode.cpp
-ws/api_client.cpp ws/client.cpp)
+ws/api_client.cpp ws/client.cpp ws/dispatcher.cpp)
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 

--- a/lib/ws/client.cpp
+++ b/lib/ws/client.cpp
@@ -29,6 +29,11 @@ namespace disccord
             return ws_api_client.connect(token);
         }
 
+        void discord_ws_client::event(ws::event ev, std::function<void ()> func)
+        {
+            dispatcher.on(static_cast<unsigned int>(ev), func);
+        }
+
         pplx::task<void> discord_ws_client::handle_frame(const disccord::models::ws::frame* frame)
         {
             switch (frame->opcode)

--- a/lib/ws/dispatcher.cpp
+++ b/lib/ws/dispatcher.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2014 Sean Farrell
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy 
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights 
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+// copies of the Software, and to permit persons to whom the Software is 
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in 
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+// SOFTWARE.
+//
+
+// MODIFIED BY: sedruk
+
+#include <stdexcept>
+
+#include <disccord/ws/dispatcher.hpp>
+
+namespace disccord
+{
+    namespace ws
+    {
+        namespace internal
+        {
+            dispatcher::dispatcher()
+            { }
+
+            dispatcher::~dispatcher()
+            { }
+
+            unsigned int dispatcher::add_listener(unsigned int event_id, std::function<void ()> cb)
+            {
+                if (!cb)
+                {
+                    throw std::invalid_argument("dispatcher::add_listener: No callbak provided.");
+                }
+                
+                std::lock_guard<std::mutex> lock(mutex);
+
+                unsigned int listener_id = ++last_listener;
+                listeners.insert(std::make_pair(event_id, std::make_shared<listener<>>(listener_id, cb)));
+
+                return listener_id;       
+            }
+
+            unsigned int dispatcher::on(unsigned int event_id, std::function<void ()> cb)
+            {
+                return add_listener(event_id, cb);
+            }
+
+            void dispatcher::remove_listener(unsigned int listener_id)
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+
+                auto i = std::find_if(listeners.begin(), listeners.end(), [&] (std::pair<const unsigned int, std::shared_ptr<listenerbase>> p) {
+                    return p.second->id == listener_id;
+                });
+                if (i != listeners.end())
+                {
+                    listeners.erase(i);
+                }
+                else
+                {
+                    throw std::invalid_argument("dispatcher::remove_listener: Invalid listener id.");
+                }
+            }
+        } // namespace internal
+    } // namespace ws
+} // namespace disccord


### PR DESCRIPTION
This is a nice event emitter/dispatcher that lets ppl pass in lambdas or void funcs when listening for gateway events.
It also makes it very easy to emit these events from inside the library code.

**NOTE:** I extended the ws client in my fork enough to be able to test this functionality.

### Example Usage for a User (Event Listening)
```cpp
#include <disccord/ws/client.hpp>

using namespace disccord;
using namespace disccord::ws;

int main()
{
    // stuff to get token etc
    // ...

    discord_ws_client client{token, token_type};

    // events can be listened to and acted on as such
    client.event(event::READY, [&client](){
        // do stuff now that client is ready
    });
    
    client.event(event::MESSAGE_CREATE, [&client](models::message msg){
        // do stuff with message
    });
    
    // <more events here>
    
    // then connect etc
    client.connect().wait();
}
```

### Example Usage in the Library (Event Dispatching)
```cpp
// inside ws/client.cpp


// in some function that is handling the opcode::DISPATCH case, may have something like this:
case event::MESSAGE_CREATE:
{
    // get message data from the frame
    auto msg = frame->get_data<disccord::models::message>();
    
    // emit message obj
    // will execute the users func/lambda if they have a client.event() listener for this event
    dispatcher.emit(event::MESSAGE_CREATE, msg);
    
    // do some extra processing for cache etc
    break;
}
```