### PR TITLE
[Util] pplx::task-compatible sleep function

### DIFF
--- a/include/disccord/util/task_sleep.hpp
+++ b/include/disccord/util/task_sleep.hpp
@@ -1,0 +1,14 @@
+#ifndef _task_sleep_hpp_
+#define _task_sleep_hpp_
+
+#include <pplx/pplxtasks.h>
+
+namespace disccord
+{
+    namespace util
+    {
+        pplx::task<void> task_sleep(uint32_t ms);
+    } // namespace util
+} // namespace disccord
+
+#endif /* _task_sleep_hpp_ */

--- a/include/disccord/util/task_sleep.hpp
+++ b/include/disccord/util/task_sleep.hpp
@@ -7,7 +7,7 @@ namespace disccord
 {
     namespace util
     {
-        pplx::task<void> task_sleep(uint32_t ms);
+        pplx::task<void> task_sleep(uint32_t s);
     } // namespace util
 } // namespace disccord
 

--- a/include/disccord/util/task_sleep.hpp
+++ b/include/disccord/util/task_sleep.hpp
@@ -7,7 +7,7 @@ namespace disccord
 {
     namespace util
     {
-        pplx::task<void> task_sleep(const uint32_t s);
+        pplx::task<void> task_sleep(const double s);
     } // namespace util
 } // namespace disccord
 

--- a/include/disccord/util/task_sleep.hpp
+++ b/include/disccord/util/task_sleep.hpp
@@ -7,7 +7,7 @@ namespace disccord
 {
     namespace util
     {
-        pplx::task<void> task_sleep(uint32_t s);
+        pplx::task<void> task_sleep(const uint32_t s);
     } // namespace util
 } // namespace disccord
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,7 +12,7 @@ set(LIBS ${LIBS} ${CPPREST_LIBRARIES} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES}
 set(SOURCE_FILES rest/api_client.cpp api/bucket_info.cpp
 api/multipart_field.cpp api/multipart_request.cpp api/multipart_file.cpp
 api/request_info.cpp rest/client.cpp util/semaphore.cpp util/url_encode.cpp
-ws/api_client.cpp ws/client.cpp)
+util/task_sleep.cpp ws/api_client.cpp ws/client.cpp)
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 

--- a/lib/util/task_sleep.cpp
+++ b/lib/util/task_sleep.cpp
@@ -15,9 +15,7 @@ namespace disccord
             boost::asio::deadline_timer t(io, boost::posix_time::milliseconds(ms));
             t.async_wait([&tce](const boost::system::error_code& err){
                 if (err)
-                {
                     tce.set_exception(std::runtime_error(err.message()));
-                }
                 else
                     tce.set();
             });

--- a/lib/util/task_sleep.cpp
+++ b/lib/util/task_sleep.cpp
@@ -7,7 +7,7 @@ namespace disccord
 {
     namespace util
     {
-        pplx::task<void> task_sleep(uint32_t s)
+        pplx::task<void> task_sleep(const uint32_t s)
         {
             pplx::task_completion_event<void> tce;
             // async timer

--- a/lib/util/task_sleep.cpp
+++ b/lib/util/task_sleep.cpp
@@ -7,7 +7,7 @@ namespace disccord
 {
     namespace util
     {
-        pplx::task<void> task_sleep(const uint32_t s)
+        pplx::task<void> task_sleep(const double s)
         {
             pplx::task_completion_event<void> tce;
             // async timer

--- a/lib/util/task_sleep.cpp
+++ b/lib/util/task_sleep.cpp
@@ -7,12 +7,12 @@ namespace disccord
 {
     namespace util
     {
-        pplx::task<void> task_sleep(uint32_t ms)
+        pplx::task<void> task_sleep(uint32_t s)
         {
             pplx::task_completion_event<void> tce;
             // async timer
             boost::asio::io_service io;
-            boost::asio::deadline_timer t(io, boost::posix_time::milliseconds(ms));
+            boost::asio::deadline_timer t(io, boost::posix_time::seconds(s));
             t.async_wait([&tce](const boost::system::error_code& err){
                 if (err)
                     tce.set_exception(std::runtime_error(err.message()));

--- a/lib/util/task_sleep.cpp
+++ b/lib/util/task_sleep.cpp
@@ -1,0 +1,28 @@
+#include <disccord/util/task_sleep.hpp>
+
+#include <boost/asio.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+namespace disccord
+{
+    namespace util
+    {
+        pplx::task<void> task_sleep(uint32_t ms)
+        {
+            pplx::task_completion_event<void> tce;
+            // async timer
+            boost::asio::io_service io;
+            boost::asio::deadline_timer t(io, boost::posix_time::milliseconds(ms));
+            t.async_wait([&tce](const boost::system::error_code& err){
+                if (err)
+                {
+                    tce.set_exception(std::runtime_error(err.message()));
+                }
+                else
+                    tce.set();
+            });
+            io.run();
+            return pplx::create_task(tce);
+        }
+    } // namespace util
+} // namespace disccord


### PR DESCRIPTION
To avoid using `std:this_thread::sleep_for()`, the current maintainer of the cpprestsdk recommended an impl using a `tce` that is set after some async timer (specifics weren't mentioned of what timer to use, so I decided to impl the timer w/ boost) . Initially this was just going to be for use in the `discord_ws_client` for heartbeating and such, but since using this lib will require you to use `pplx::task`s, might as well make this a util so it can be used outside of library specifics (for bot commands that may require waiting, etc).

Also not super set on the name (although I don't mind it), so suggestions there would be appreciated too.

### Example Usage in the Library (Heartbeating)
```cpp
// inside ws/client.cpp

pplx::task<void> discord_ws_client::heartbeat_loop(int wait_ms)
{
    return pplx::create_task([wait_ms, this](){
        while (<stuff>)
        {
            // have some client state checks or whatever here
            // ...

            // send heartbeat payload
            // ...

            // night night
            auto s = static_cast<double>(wait_ms)/1000;
            util::task_sleep(s).then([this](){
                // maybe do something else after sleep before next loop?
            }).wait();
        }
    });
}
```