### PR TITLE
[Websocket] Fix Frame Model, Start Heartbeat Logic

### DIFF
--- a/include/disccord/util/task_sleep.hpp
+++ b/include/disccord/util/task_sleep.hpp
@@ -1,0 +1,14 @@
+#ifndef _task_sleep_hpp_
+#define _task_sleep_hpp_
+
+#include <pplx/pplxtasks.h>
+
+namespace disccord
+{
+    namespace util
+    {
+        pplx::task<void> task_sleep(const double s);
+    } // namespace util
+} // namespace disccord
+
+#endif /* _task_sleep_hpp_ */

--- a/include/disccord/ws/api_client.hpp
+++ b/include/disccord/ws/api_client.hpp
@@ -36,6 +36,8 @@ namespace disccord
                     pplx::task<void> send(ws::opcode op, web::json::value payload);
 
                     void set_frame_handler(const std::function<pplx::task<void>(const disccord::models::ws::frame*)>& func);
+                    
+                    pplx::task<void> send_heartbeat(const uint32_t sequence = 0);
 
                 private:
                     web::websockets::client::websocket_client ws_client;

--- a/include/disccord/ws/api_client.hpp
+++ b/include/disccord/ws/api_client.hpp
@@ -6,6 +6,8 @@
 
 #include <cpprest/ws_client.h>
 
+#include <disccord/ws/opcode.hpp>
+
 #include <disccord/types.hpp>
 #include <disccord/models/ws/frame.hpp>
 
@@ -30,6 +32,8 @@ namespace disccord
                     virtual ~ws_api_client();
 
                     pplx::task<void> connect(const pplx::cancellation_token& token = pplx::cancellation_token::none());
+                    
+                    pplx::task<void> send(ws::opcode op, web::json::value payload);
 
                     void set_frame_handler(const std::function<pplx::task<void>(const disccord::models::ws::frame*)>& func);
 

--- a/include/disccord/ws/client.hpp
+++ b/include/disccord/ws/client.hpp
@@ -30,7 +30,7 @@ namespace disccord
                 pplx::task<void> heartbeat_task;
 
                 pplx::task<void> handle_frame(const disccord::models::ws::frame* frame);
-                pplx::task<void> heartbeat_loop(int wait_millis);
+                void heartbeat_loop(int wait_millis);
         };
     }
 }

--- a/include/disccord/ws/client.hpp
+++ b/include/disccord/ws/client.hpp
@@ -29,8 +29,10 @@ namespace disccord
                 pplx::cancellation_token_source heartbeat_cancel_token;
                 pplx::task<void> heartbeat_task;
 
+                uint32_t seq;
+
                 pplx::task<void> handle_frame(const disccord::models::ws::frame* frame);
-                void heartbeat_loop(int wait_millis);
+                pplx::task<void> heartbeat_loop(int wait_millis);
         };
     }
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,7 +12,7 @@ set(LIBS ${LIBS} ${CPPREST_LIBRARIES} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES}
 set(SOURCE_FILES rest/api_client.cpp api/bucket_info.cpp
 api/multipart_field.cpp api/multipart_request.cpp api/multipart_file.cpp
 api/request_info.cpp rest/client.cpp util/semaphore.cpp util/url_encode.cpp
-ws/api_client.cpp ws/client.cpp)
+util/task_sleep.cpp ws/api_client.cpp ws/client.cpp)
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 

--- a/lib/util/task_sleep.cpp
+++ b/lib/util/task_sleep.cpp
@@ -1,0 +1,26 @@
+#include <disccord/util/task_sleep.hpp>
+
+#include <boost/asio.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+namespace disccord
+{
+    namespace util
+    {
+        pplx::task<void> task_sleep(const double s)
+        {
+            pplx::task_completion_event<void> tce;
+            // async timer
+            boost::asio::io_service io;
+            boost::asio::deadline_timer t(io, boost::posix_time::seconds(s));
+            t.async_wait([&tce](const boost::system::error_code& err){
+                if (err)
+                    tce.set_exception(std::runtime_error(err.message()));
+                else
+                    tce.set();
+            });
+            io.run();
+            return pplx::create_task(tce);
+        }
+    } // namespace util
+} // namespace disccord

--- a/lib/ws/api_client.cpp
+++ b/lib/ws/api_client.cpp
@@ -51,6 +51,14 @@ namespace disccord
                 });
             }
 
+            pplx::task<void> ws_api_client::send(ws::opcode op, web::json::value payload)
+            {
+                payload["op"] = web::json::value(static_cast<int>(op));
+                websocket_outgoing_message gateway_msg;
+                gateway_msg.set_utf8_message(std::move(payload.serialize()));
+                return ws_client.send(gateway_msg);
+            }
+
             void ws_api_client::set_frame_handler(const std::function<pplx::task<void>(const disccord::models::ws::frame*)>& func)
             {
                 message_handler = func;

--- a/lib/ws/api_client.cpp
+++ b/lib/ws/api_client.cpp
@@ -106,6 +106,16 @@ namespace disccord
 
                 return pplx::create_task([](){});
             }
+            
+            pplx::task<void> ws_api_client::send_heartbeat(const uint32_t sequence)
+            {
+                web::json::value payload;
+                if (!sequence)
+                    payload["d"] = web::json::value::null();
+                else
+                    payload["d"] = web::json::value(sequence);
+                return send(ws::opcode::HEARTBEAT, payload);
+            }
         }
     }
 }

--- a/lib/ws/client.cpp
+++ b/lib/ws/client.cpp
@@ -3,8 +3,6 @@
 #include <disccord/rest.hpp>
 #include <disccord/ws/client.hpp>
 
-#include <disccord/ws/opcode.hpp>
-
 #include <disccord/util/task_sleep.hpp>
 
 #include <disccord/models/ws/hello.hpp>

--- a/lib/ws/client.cpp
+++ b/lib/ws/client.cpp
@@ -5,6 +5,8 @@
 
 #include <disccord/ws/opcode.hpp>
 
+#include <disccord/models/ws/hello.hpp>
+
 namespace disccord
 {
     namespace ws
@@ -34,8 +36,12 @@ namespace disccord
             switch (frame->op)
             {
                 case opcode::HELLO:
+                {
+                    auto data = frame->get_data<models::ws::hello>();
+
                     //heartbeat_task = pplx::create_task(std::bind)
                     break;
+                }
                 default:
                     std::cout << "Unhandled opcode " << static_cast<uint32_t>(frame->op) << std::endl;
             }

--- a/lib/ws/client.cpp
+++ b/lib/ws/client.cpp
@@ -31,13 +31,13 @@ namespace disccord
 
         pplx::task<void> discord_ws_client::handle_frame(const disccord::models::ws::frame* frame)
         {
-            switch (frame->opcode)
+            switch (frame->op)
             {
                 case opcode::HELLO:
                     //heartbeat_task = pplx::create_task(std::bind)
                     break;
                 default:
-                    std::cout << "Unhandled opcode " << static_cast<uint32_t>(frame->opcode) << std::endl;
+                    std::cout << "Unhandled opcode " << static_cast<uint32_t>(frame->op) << std::endl;
             }
 
             return pplx::create_task([](){});

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -20,7 +20,7 @@ rest/bulk_delete_message_args.lua rest/edit_channel_permissions_args.lua
 rest/add_dm_recipient_args.lua rest/guild_prune_args.lua
 rest/edit_current_user_nick_args.lua rest/edit_current_user_args.lua
 
-ws/frame.lua)
+ws/frame.lua ws/hello.lua)
 
 foreach(MODEL IN ITEMS ${MODELS})
     string(REGEX REPLACE "\\.[^.]*$" "" MODEL ${MODEL})

--- a/models/ws/frame.lua
+++ b/models/ws/frame.lua
@@ -1,14 +1,14 @@
 include("disccord/ws/opcode.hpp")
 
 model{"frame",
-    property{"opcode", "disccord::ws::opcode"},
-    property{"sequence", "disccord::util::optional<uint32_t>"},
-    property{"event", "disccord::util::optional<std::string>"},
+    property{"op", "disccord::ws::opcode"},
+    property{"s", "disccord::util::optional<uint32_t>"},
+    property{"t", "disccord::util::optional<std::string>"},
 
-    field{"data", "web::json::value"},
+    field{"d", "web::json::value"},
 
     method{"get_data", "TModel",
-        [[TModel model; model.decode(data); return model;]],
+        [[TModel model; model.decode(d); return model;]],
         {pre = "template <typename TModel>", post = "const"}
     }
 }

--- a/models/ws/hello.lua
+++ b/models/ws/hello.lua
@@ -1,0 +1,4 @@
+model{"hello",
+    property{"heartbeat_interval", "uint32_t"},
+    property{"trace", "std::vector<std::string>"}
+}


### PR DESCRIPTION
For the `util::task_sleep` addition, see #43

The names of the frame properties/fields that are generated need to match the actual JSON data we get from the message. Right now we never actually get to handling any opcodes because a JSON exception is being thrown since it is looking for keys that dont exist.

Also added the hello model and started off the heartbeat stuff.

**NOTE:** It would be nice to have a writable `models::ws::frame` equiv as well. ATM the current model doesn't account for wanting to send a `null` value for the `d` key, which is needed for heartbeats. Then that could be the single param for `ws_api_client::send()` instead of the current interface. But for right now this is fine.

Tested 👍 