### PR TITLE
[Websocket] Support All Opcodes

### DIFF
--- a/include/disccord/types.hpp
+++ b/include/disccord/types.hpp
@@ -58,6 +58,12 @@ namespace disccord
         CHANNEL_PINNED_MESSAGE,
         GUILD_MEMBER_JOIN
     };
+    
+    enum class game_type
+    {
+        GAME,
+        STREAMING
+    };
 }
 
 #endif /* _types_hpp_ */

--- a/include/disccord/ws/api_client.hpp
+++ b/include/disccord/ws/api_client.hpp
@@ -46,6 +46,8 @@ namespace disccord
                     pplx::task<void> send_resume(const std::string& session_id, const uint32_t sequence);
                     
                     pplx::task<void> send_status_update(const std::string& status, models::game game, bool afk = false, uint64_t since = 0);
+                    
+                    pplx::task<void> send_request_guild_members(const disccord::snowflake guild_id, const std::string& query = "", const uint32_t limit = 0);
 
                 private:
                     web::websockets::client::websocket_client ws_client;

--- a/include/disccord/ws/api_client.hpp
+++ b/include/disccord/ws/api_client.hpp
@@ -45,9 +45,11 @@ namespace disccord
                     
                     pplx::task<void> send_resume(const std::string& session_id, const uint32_t sequence);
                     
-                    pplx::task<void> send_status_update(const std::string& status, models::game game, bool afk = false, uint64_t since = 0);
+                    pplx::task<void> send_status_update(const std::string& status, const models::game game, const bool afk = false, const uint64_t since = 0);
                     
                     pplx::task<void> send_request_guild_members(const disccord::snowflake guild_id, const std::string& query = "", const uint32_t limit = 0);
+                    
+                    pplx::task<void> send_voice_state_update(const disccord::snowflake guild_id, const bool self_mute = false, const bool self_deaf = false, const disccord::snowflake channel_id = 0);
 
                 private:
                     web::websockets::client::websocket_client ws_client;

--- a/include/disccord/ws/api_client.hpp
+++ b/include/disccord/ws/api_client.hpp
@@ -50,6 +50,8 @@ namespace disccord
                     pplx::task<void> send_request_guild_members(const disccord::snowflake guild_id, const std::string& query = "", const uint32_t limit = 0);
                     
                     pplx::task<void> send_voice_state_update(const disccord::snowflake guild_id, const bool self_mute = false, const bool self_deaf = false, const disccord::snowflake channel_id = 0);
+                    
+                    pplx::task<void> send_guild_sync(const std::vector<disccord::snowflake> guild_ids);
 
                 private:
                     web::websockets::client::websocket_client ws_client;

--- a/include/disccord/ws/api_client.hpp
+++ b/include/disccord/ws/api_client.hpp
@@ -38,6 +38,9 @@ namespace disccord
                     void set_frame_handler(const std::function<pplx::task<void>(const disccord::models::ws::frame*)>& func);
                     
                     pplx::task<void> send_heartbeat(const uint32_t sequence = 0);
+                    
+                    // TODO: have a default `presence` object
+                    pplx::task<void> send_identify(const uint16_t shard_id = 0, const uint16_t shard_count = 1, const bool compress = false, const uint16_t large_threshold = 100);
 
                 private:
                     web::websockets::client::websocket_client ws_client;

--- a/include/disccord/ws/api_client.hpp
+++ b/include/disccord/ws/api_client.hpp
@@ -41,6 +41,8 @@ namespace disccord
                     
                     // TODO: have a default `presence` object
                     pplx::task<void> send_identify(const uint16_t shard_id = 0, const uint16_t shard_count = 1, const bool compress = false, const uint16_t large_threshold = 100);
+                    
+                    pplx::task<void> send_resume(const std::string& session_id, const uint32_t sequence);
 
                 private:
                     web::websockets::client::websocket_client ws_client;

--- a/include/disccord/ws/api_client.hpp
+++ b/include/disccord/ws/api_client.hpp
@@ -9,6 +9,7 @@
 #include <disccord/ws/opcode.hpp>
 
 #include <disccord/types.hpp>
+#include <disccord/models/game.hpp>
 #include <disccord/models/ws/frame.hpp>
 
 namespace disccord
@@ -43,6 +44,8 @@ namespace disccord
                     pplx::task<void> send_identify(const uint16_t shard_id = 0, const uint16_t shard_count = 1, const bool compress = false, const uint16_t large_threshold = 100);
                     
                     pplx::task<void> send_resume(const std::string& session_id, const uint32_t sequence);
+                    
+                    pplx::task<void> send_status_update(const std::string& status, models::game game, bool afk = false, uint64_t since = 0);
 
                 private:
                     web::websockets::client::websocket_client ws_client;

--- a/include/disccord/ws/client.hpp
+++ b/include/disccord/ws/client.hpp
@@ -2,6 +2,8 @@
 #define _ws_client_hpp_
 
 #include <string>
+#include <queue>
+#include <chrono>
 
 #include <cpprest/ws_client.h>
 
@@ -21,18 +23,30 @@ namespace disccord
                 virtual ~discord_ws_client();
 
                 pplx::task<void> connect(const pplx::cancellation_token& token = pplx::cancellation_token::none());
+                
+                uint32_t get_latency() const;
 
             private:
+                using time = std::chrono::time_point<std::chrono::high_resolution_clock>;
+
                 disccord::rest::internal::rest_api_client rest_api_client;
                 disccord::ws::internal::ws_api_client ws_api_client;
 
                 pplx::cancellation_token_source heartbeat_cancel_token;
                 pplx::task<void> heartbeat_task;
 
+                std::queue<time> heartbeat_times;
+                time last_message_time;
+
                 uint32_t seq;
+                std::string session_id;
+
+                uint32_t latency;
 
                 pplx::task<void> handle_frame(const disccord::models::ws::frame* frame);
-                pplx::task<void> heartbeat_loop(int wait_millis);
+                pplx::task<void> heartbeat_loop(int wait_ms);
+                
+                pplx::task<void> handle_dispatch(const disccord::models::ws::frame* frame);
         };
     }
 }

--- a/include/disccord/ws/client.hpp
+++ b/include/disccord/ws/client.hpp
@@ -19,12 +19,13 @@ namespace disccord
         class discord_ws_client
         {
             public:
-                discord_ws_client(std::string token, disccord::token_type type);
+                discord_ws_client(std::string token, disccord::token_type type, uint16_t shard_id = 0, uint16_t shard_count = 1);
                 virtual ~discord_ws_client();
 
                 pplx::task<void> connect(const pplx::cancellation_token& token = pplx::cancellation_token::none());
                 
                 uint32_t get_latency() const;
+                uint32_t get_shard_id() const;
 
             private:
                 using time = std::chrono::time_point<std::chrono::high_resolution_clock>;
@@ -41,6 +42,8 @@ namespace disccord
                 uint32_t seq;
                 std::string session_id;
 
+                uint16_t shard_id;
+                uint16_t shard_count;
                 uint32_t latency;
 
                 pplx::task<void> handle_frame(const disccord::models::ws::frame* frame);

--- a/include/disccord/ws/client.hpp
+++ b/include/disccord/ws/client.hpp
@@ -49,7 +49,7 @@ namespace disccord
                 pplx::task<void> handle_frame(const disccord::models::ws::frame* frame);
                 pplx::task<void> heartbeat_loop(int wait_ms);
                 
-                pplx::task<void> handle_dispatch(const disccord::models::ws::frame* frame);
+                void handle_dispatch(const disccord::models::ws::frame* frame);
         };
     }
 }

--- a/lib/ws/api_client.cpp
+++ b/lib/ws/api_client.cpp
@@ -10,6 +10,7 @@
 #include <disccord/models/ws/identify_args.hpp>
 #include <disccord/models/ws/resume_args.hpp>
 #include <disccord/models/ws/status_update_args.hpp>
+#include <disccord/models/ws/request_guild_members_args.hpp>
 
 // This is purely for my sanity. Don't ever do this, ever.
 using namespace web::websockets::client;
@@ -157,6 +158,16 @@ namespace disccord
                     payload["d"]["since"] = web::json::value::null();
                 
                 return send(ws::opcode::PRESENCE, payload);
+            }
+            
+            pplx::task<void> ws_api_client::send_request_guild_members(const disccord::snowflake guild_id, const std::string& query, const uint32_t limit)
+            {
+                models::ws::request_guild_members_args args{guild_id, query, limit};
+                
+                web::json::value payload;
+                payload["d"] = args.encode();
+                
+                return send(ws::opcode::REQUEST_MEMBERS, payload);
             }
         }
     }

--- a/lib/ws/api_client.cpp
+++ b/lib/ws/api_client.cpp
@@ -135,6 +135,16 @@ namespace disccord
                 
                 return send(ws::opcode::IDENTIFY, payload);
             }
+            
+            pplx::task<void> ws_api_client::send_resume(const std::string& session_id, const uint32_t sequence)
+            {
+                web::json::value payload;
+                payload["d"]["token"] = web::json::value(token);
+                payload["d"]["session_id"] = web::json::value(session_id);
+                payload["d"]["seq"] = web::json::value(sequence);
+                
+                return send(ws::opcode::RESUME, payload);
+            }
         }
     }
 }

--- a/lib/ws/api_client.cpp
+++ b/lib/ws/api_client.cpp
@@ -12,6 +12,7 @@
 #include <disccord/models/ws/status_update_args.hpp>
 #include <disccord/models/ws/request_guild_members_args.hpp>
 #include <disccord/models/ws/voice_state_update_args.hpp>
+#include <disccord/models/ws/guild_sync_args.hpp>
 
 // This is purely for my sanity. Don't ever do this, ever.
 using namespace web::websockets::client;
@@ -179,6 +180,14 @@ namespace disccord
                 payload["d"] = args.encode();
                 
                 return send(ws::opcode::VOICE_STATE, payload);
+            }
+            
+            pplx::task<void> ws_api_client::send_guild_sync(const std::vector<disccord::snowflake> guild_ids)
+            {
+                // in this opcode, the `d` key maps to guild_ids
+                models::ws::guild_sync_args args{guild_ids};
+                
+                return send(ws::opcode::GUILD_SYNC, args.encode());
             }
         }
     }

--- a/lib/ws/api_client.cpp
+++ b/lib/ws/api_client.cpp
@@ -116,6 +116,25 @@ namespace disccord
                     payload["d"] = web::json::value(sequence);
                 return send(ws::opcode::HEARTBEAT, payload);
             }
+            
+            pplx::task<void> ws_api_client::send_identify(const uint16_t shard_id, const uint16_t shard_count, const bool compress, const uint16_t large_threshold)
+            {
+                std::vector<web::json::value> shard_array = {web::json::value(shard_id), web::json::value(shard_count)};
+                
+                web::json::value payload;
+                payload["d"]["token"] = web::json::value(token);
+                payload["d"]["properties"]["$os"] = web::json::value("linux");
+                payload["d"]["properties"]["$browser"] = web::json::value("disccord");
+                payload["d"]["properties"]["$device"] = web::json::value("disccord");
+                payload["d"]["properties"]["$referrer"] = web::json::value("");
+                payload["d"]["properties"]["$referring_domain"] = web::json::value("");
+                payload["d"]["compress"] = web::json::value(compress);
+                payload["d"]["large_threshold"] = web::json::value(large_threshold);
+                payload["d"]["shard"] = web::json::value::array(shard_array);
+                // TODO: payload["d"]["presence"]
+                
+                return send(ws::opcode::IDENTIFY, payload);
+            }
         }
     }
 }

--- a/lib/ws/client.cpp
+++ b/lib/ws/client.cpp
@@ -80,10 +80,22 @@ namespace disccord
                 }
                 case opcode::INVALIDATE_SESSION:
                 {
+                    seq = 0;
+                    session_id = "";
+
+                    if (frame->d.as_bool())
+                    {
+                       // TODO: Reconnect here 
+                    }
+                    else 
+                    {
+                       //ws_api_client.send_identify(<stuff>).wait(); 
+                    }
                     break;
                 }
                 case opcode::RECONNECT:
                 {
+                    // TODO: Reconnect here
                     break;
                 }
                 case opcode::DISPATCH:

--- a/lib/ws/client.cpp
+++ b/lib/ws/client.cpp
@@ -59,7 +59,7 @@ namespace disccord
                     auto func = std::bind(&discord_ws_client::heartbeat_loop, this, data.heartbeat_interval);
                     heartbeat_task = pplx::create_task(func, pplx::task_options(heartbeat_cancel_token.get_token()));
                     
-                    ws_api_client.send_identify(shard_id, shard_count).wait(); 
+                    ws_api_client.send_identify(shard_id, shard_count).wait();
 
                     break;
                 }

--- a/lib/ws/client.cpp
+++ b/lib/ws/client.cpp
@@ -107,7 +107,7 @@ namespace disccord
                 }
                 case opcode::DISPATCH:
                 {
-                    handle_dispatch(frame).wait();
+                    handle_dispatch(frame);
                     break;
                 }
                 default:
@@ -148,10 +148,9 @@ namespace disccord
             });
         }
         
-        pplx::task<void> discord_ws_client::handle_dispatch(const disccord::models::ws::frame* frame)
+        void discord_ws_client::handle_dispatch(const disccord::models::ws::frame* frame)
         {
             // TODO: handle events
-            return pplx::create_task([](){});
         }
     }
 }

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${CPPREST_INCLUDE_DIRS}
 set(MODELS user.lua gateway_info.lua channel.lua connection.lua
 guild.lua guild_embed.lua guild_member.lua integration.lua invite.lua
 message.lua role.lua user_guild.lua voice_region.lua invite_metadata.lua
-read_state.lua ban.lua application.lua voice_state.lua
+read_state.lua ban.lua application.lua voice_state.lua game.lua
 
 rest/add_guild_member_args.lua rest/create_channel_invite_args.lua
 rest/create_guild_channel_args.lua rest/create_message_args.lua
@@ -20,7 +20,8 @@ rest/bulk_delete_message_args.lua rest/edit_channel_permissions_args.lua
 rest/add_dm_recipient_args.lua rest/guild_prune_args.lua
 rest/edit_current_user_nick_args.lua rest/edit_current_user_args.lua
 
-ws/frame.lua ws/hello.lua)
+ws/frame.lua ws/hello.lua ws/identify_args.lua ws/resume_args.lua
+ws/status_update_args.lua)
 
 foreach(MODEL IN ITEMS ${MODELS})
     string(REGEX REPLACE "\\.[^.]*$" "" MODEL ${MODEL})

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -22,7 +22,7 @@ rest/edit_current_user_nick_args.lua rest/edit_current_user_args.lua
 
 ws/frame.lua ws/hello.lua ws/identify_args.lua ws/resume_args.lua
 ws/status_update_args.lua ws/request_guild_members_args.lua
-ws/voice_state_update_args.lua)
+ws/voice_state_update_args.lua ws/guild_sync_args.lua)
 
 foreach(MODEL IN ITEMS ${MODELS})
     string(REGEX REPLACE "\\.[^.]*$" "" MODEL ${MODEL})

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -21,7 +21,8 @@ rest/add_dm_recipient_args.lua rest/guild_prune_args.lua
 rest/edit_current_user_nick_args.lua rest/edit_current_user_args.lua
 
 ws/frame.lua ws/hello.lua ws/identify_args.lua ws/resume_args.lua
-ws/status_update_args.lua ws/request_guild_members_args.lua)
+ws/status_update_args.lua ws/request_guild_members_args.lua
+ws/voice_state_update_args.lua)
 
 foreach(MODEL IN ITEMS ${MODELS})
     string(REGEX REPLACE "\\.[^.]*$" "" MODEL ${MODEL})

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -21,7 +21,7 @@ rest/add_dm_recipient_args.lua rest/guild_prune_args.lua
 rest/edit_current_user_nick_args.lua rest/edit_current_user_args.lua
 
 ws/frame.lua ws/hello.lua ws/identify_args.lua ws/resume_args.lua
-ws/status_update_args.lua)
+ws/status_update_args.lua ws/request_guild_members_args.lua)
 
 foreach(MODEL IN ITEMS ${MODELS})
     string(REGEX REPLACE "\\.[^.]*$" "" MODEL ${MODEL})

--- a/models/game.lua
+++ b/models/game.lua
@@ -1,0 +1,5 @@
+model{"game",
+    property{"name", "std::string"},
+    property{"url", "disccord::util::optional<std::string>"},
+    property{"type", "disccord::game_type"}
+}

--- a/models/ws/frame.lua
+++ b/models/ws/frame.lua
@@ -4,8 +4,7 @@ model{"frame",
     property{"op", "disccord::ws::opcode"},
     property{"s", "disccord::util::optional<uint32_t>"},
     property{"t", "disccord::util::optional<std::string>"},
-
-    field{"d", "web::json::value"},
+    property{"d", "web::json::value"},
 
     method{"get_data", "TModel",
         [[TModel model; model.decode(d); return model;]],

--- a/models/ws/guild_sync_args.lua
+++ b/models/ws/guild_sync_args.lua
@@ -1,0 +1,3 @@
+model{"guild_sync_args",
+    property{"d", "std::vector<disccord::snowflake>"}
+}

--- a/models/ws/identify_args.lua
+++ b/models/ws/identify_args.lua
@@ -1,0 +1,7 @@
+model{"identify_args",
+    property{"token", "std::string"},
+    property{"compress", "bool"},
+    property{"large_threshold", "uint16_t"},
+    property{"shard", "std::vector<web::json::value>"}
+    --property{"presence", "<type>"}
+}

--- a/models/ws/request_guild_members_args.lua
+++ b/models/ws/request_guild_members_args.lua
@@ -1,0 +1,5 @@
+model{"request_guild_members_args",
+    property{"guild_id", "disccord::snowflake"},
+    property{"query", "std::string"},
+    property{"limit", "uint32_t"}
+}

--- a/models/ws/resume_args.lua
+++ b/models/ws/resume_args.lua
@@ -1,0 +1,5 @@
+model{"resume_args",
+    property{"token", "std::string"},
+    property{"session_id", "std::string"},
+    property{"seq", "uint32_t"}
+}

--- a/models/ws/status_update_args.lua
+++ b/models/ws/status_update_args.lua
@@ -4,5 +4,5 @@ model{"status_update_args",
     property{"status", "std::string"},
     property{"game", "disccord::models::game"},
     property{"afk", "bool"},
-    property{"since", "uint64_t"}
+    property{"since", "disccord::util::optional<uint64_t>"}
 }

--- a/models/ws/status_update_args.lua
+++ b/models/ws/status_update_args.lua
@@ -1,0 +1,8 @@
+include("disccord/models/game.hpp")
+
+model{"status_update_args",
+    property{"status", "std::string"},
+    property{"game", "disccord::models::game"},
+    property{"afk", "bool"},
+    property{"since", "uint64_t"}
+}

--- a/models/ws/voice_state_update_args.lua
+++ b/models/ws/voice_state_update_args.lua
@@ -1,0 +1,6 @@
+model{"voice_state_update_args",
+    property{"guild_id", "disccord::snowflake"},
+    property{"self_mute", "bool"},
+    property{"self_deaf", "bool"},
+    property{"channel_id", "disccord::util::optional<disccord::snowflake>"}
+}

--- a/tools/generate_models.lua
+++ b/tools/generate_models.lua
@@ -169,6 +169,7 @@ local generate_encode_body, generate_decode_body do
         ["disccord::notification_level"] = "uint32_t",
         ["disccord::mfa_level"] = "uint32_t",
         ["disccord::message_type"] = "uint32_t",
+        ["disccord::game_type"] = "uint32_t",
         ["disccord::permissions"] = "uint32_t",
         ["disccord::ws::opcode"] = "uint32_t"
     }


### PR DESCRIPTION
This PR is just handling the **basic/simple** essentials for receiving and sending all the opcodes.

Things that are out of scope for this PR:
- Logging
- Any Reconnect/Resume logic
- Handling the dispatch Events

This PR satisfies Identify logic in #6 , and almost all (95%-ish) of heartbeat logic. (the last TODO for heartbeats requires connection state and is outside the scope of initial release anyways)